### PR TITLE
Improve StatsSpec and fix an issue with macro did

### DIFF
--- a/src/did.jl
+++ b/src/did.jl
@@ -87,7 +87,7 @@ with the specified arguments.
 """
 didspec(args...; kwargs...) = StatsSpec(_didargs(args...; kwargs...)...)
 
-function _show_args(io::IO, sp::StatsSpec{A,<:DiffinDiffsEstimator}) where A
+function _show_args(io::IO, sp::StatsSpec{<:DiffinDiffsEstimator})
     if haskey(sp.args, :tr) || haskey(sp.args, :pr)
         print(io, ":")
         haskey(sp.args, :tr) && print(io, "\n  ", sp.args[:tr])
@@ -139,7 +139,7 @@ macro did(args...)
     nargs = length(args)
     options = :(Dict{Symbol, Any}())
     noproceed = false
-    didargs = []
+    didargs = ()
     if nargs > 0
         if isexpr(args[1], :vect, :hcat, :vcat)
             noproceed = _parse!(options, args[1].args)
@@ -150,9 +150,9 @@ macro did(args...)
     end
     dargs, dkwargs = _args_kwargs(didargs)
     if noproceed
-        return esc(:(StatsSpec(valid_didargs(parse_didargs($(dargs...); $(dkwargs...)))...)))
+        return :(StatsSpec(valid_didargs(parse_didargs($(esc.(dargs)...); $(esc.(dkwargs)...)))...))
     else
-        return esc(:(StatsSpec(valid_didargs(parse_didargs($(dargs...); $(dkwargs...)))...)(; $options...)))
+        return :(StatsSpec(valid_didargs(parse_didargs($(esc.(dargs)...); $(esc.(dkwargs)...)))...)(; $(esc(options))...))
     end
 end
 

--- a/test/StatsProcedures.jl
+++ b/test/StatsProcedures.jl
@@ -1,4 +1,4 @@
-using DiffinDiffsBase: _f, _get, groupargs,
+using DiffinDiffsBase: _f, _get, groupargs, _get_default,
     _sharedby, _show_args, _args_kwargs, _parse!, pool, proceed
 import DiffinDiffsBase: required, default, transformed, combinedargs
 
@@ -26,20 +26,20 @@ combinedargs(::TestCombineStep, ntargs) = [nt.b for nt in ntargs]
 
 testinvalidstep(a::String, b::String) = b, false
 const TestInvalidStep = StatsStep{:TestInvalidStep, typeof(testinvalidstep)}
-default(::TestInvalidStep) = (a="a",b="b")
+default(::TestInvalidStep) = (a="a", b="b")
 
 const TestUnnamedStep = StatsStep{:TestUnnamedStep, typeof(testinvalidstep)}
 
 @testset "StatsStep" begin
     @testset "_get" begin
-        @test _get((), NamedTuple()) == ()
-        @test _get((:a,), (a=1, b=2)) == (1,)
-        @test_throws ErrorException _get((:a,), (b=2,))
+        @test _get(NamedTuple(), ()) == ()
+        @test _get((a=1, b=2), (:a,)) == (1,)
+        @test_throws ErrorException _get((b=2,), (:a,))
 
         @test _get(NamedTuple(), NamedTuple()) == ()
-        @test _get((a=1,), (b=2,)) == (1,)
-        @test _get((a=1,), (a=1, b=2)) == (1,)
-        @test _get((a=1, b=2), (a=2,)) == (2, 2)
+        @test _get((a=1,), (b=2,)) == (2,)
+        @test _get((a=1,), (a=2, b=2)) == (1, 2)
+        @test _get((a=1, b=2), (a=2,)) == (1,)
     end
 
     @testset "args" begin
@@ -124,6 +124,12 @@ const ep = EP()
     @test sprint(show, np) == "NullProcedure"
     @test sprint(show, MIME("text/plain"), np) == """
         NullProcedure (TestProcedure with 0 step)"""
+end
+
+@testset "_get_default" begin
+    @test _get_default(rp, NamedTuple()) == (a="a", b="b")
+    @test _get_default(rp, (a="a1",)) == (a="a1", b="b")
+    @test _get_default(rp, (c="c",)) == (a="a", b="b", c="c")
 end
 
 @testset "SharedStatsStep" begin


### PR DESCRIPTION
`StatsSpec` now has only one type parameter.

`@did` no longer assumes `StatsSpec` and functions that prepare the arguments are in the `Main` module.

A new helper function `_get_default` is added for merging default values into the named tuple of arguments.
