### PR TITLE
Do not generate NamedTuples until valid_didargs

### DIFF
--- a/src/StatsProcedures.jl
+++ b/src/StatsProcedures.jl
@@ -163,15 +163,6 @@ function show(io::IO, ::MIME"text/plain", p::AbstractStatsProcedure{A,T}) where 
 end
 
 """
-    _get_default(p::AbstractStatsProcedure, ntargs::NamedTuple)
-
-Obtain default values for arguments of each [`StatsStep`](@ref) in procedure `p`
-and then merge any default value for arguments not found in `ntargs` into `ntargs`.
-"""
-_get_default(p::AbstractStatsProcedure, @nospecialize(ntargs::NamedTuple)) =
-    merge((default(s) for s in p)..., ntargs)
-
-"""
     SharedStatsStep
 
 A [`StatsStep`](@ref) that is possibly shared by
@@ -583,24 +574,24 @@ function _parse!(options::Expr, args)
     return false
 end
 
-function _spec_walker1(x, parsers, formatters, ntargs_set)
+function _spec_walker1(x, parsers, formatters, args_set)
     @capture(x, spec_(formatter_(parser_(rawargs__))...)(;o__)) || return x
     # spec may be a GlobalRef
     name = spec isa Symbol ? spec : spec.name
     name == :StatsSpec || return x
     push!(parsers, parser)
     push!(formatters, formatter)
-    return :(push!($ntargs_set, $parser($(rawargs...))))
+    return :(push!($args_set, $parser($(rawargs...))))
 end
 
-function _spec_walker2(x, parsers, formatters, ntargs_set)
+function _spec_walker2(x, parsers, formatters, args_set)
     @capture(x, spec_(formatter_(parser_(rawargs__))...)) || return x
     # spec may be a GlobalRef
     name = spec isa Symbol ? spec : spec.name
     name == :StatsSpec || return x
     push!(parsers, parser)
     push!(formatters, formatter)
-    return :(push!($ntargs_set, $parser($(rawargs...))))
+    return :(push!($args_set, $parser($(rawargs...))))
 end
 
 """
@@ -647,7 +638,7 @@ The following options are available for altering the behavior of `@specset`:
 macro specset(args...)
     nargs = length(args)
     nargs == 0 && throw(ArgumentError("no argument is found for @specset"))
-    options = :(Dict{Symbol, Any}())
+    options = :(Dict{Symbol,Any}())
     noproceed = false
     default_args = nothing
     if nargs > 1
@@ -663,9 +654,9 @@ macro specset(args...)
         throw(ArgumentError("last argument to @specset must be begin/end block or for loop"))
 
     # parser and formatter may be GlobalRef
-    parsers, formatters, ntargs_set = [], [], NamedTuple[]
-    walked = postwalk(x->_spec_walker1(x, parsers, formatters, ntargs_set), specs)
-    walked = postwalk(x->_spec_walker2(x, parsers, formatters, ntargs_set), walked)
+    parsers, formatters, args_set = [], [], Dict{Symbol,Any}[]
+    walked = postwalk(x->_spec_walker1(x, parsers, formatters, args_set), specs)
+    walked = postwalk(x->_spec_walker2(x, parsers, formatters, args_set), walked)
     nparser = length(unique!(parsers))
     nparser == 1 ||
         throw(ArgumentError("found $nparser parsers from arguments while expecting one"))
@@ -675,17 +666,17 @@ macro specset(args...)
     
     parser, formatter = parsers[1], formatters[1]
     if default_args === nothing
-        defaults = :(NamedTuple())
+        defaults = :(Dict{Symbol,Any}())
     else
-        defaults = esc(:($parser($(default_args[1]...); $(default_args[2]...))))
+        defaults = esc(:($parser($(default_args[1]), $(default_args[2]))))
     end
 
     blk = quote
         $(esc(walked))
-        local nspec = length($ntargs_set)
+        local nspec = length($args_set)
         local sps = Vector{StatsSpec}(undef, nspec)
         for i in 1:nspec
-            sps[i] = StatsSpec($(esc(formatter))(merge($defaults, $ntargs_set[i]))...)
+            sps[i] = StatsSpec($(esc(formatter))(merge($defaults, $args_set[i]))...)
         end
     end
 

--- a/src/StatsProcedures.jl
+++ b/src/StatsProcedures.jl
@@ -460,7 +460,7 @@ becomes an element in the returned `Vector` for each [`StatsSpec`](@ref).
 When either `keep` or `keepall` is specified,
 a `NamedTuple` with additional objects is formed for each [`StatsSpec`](@ref).
 """
-function proceed(sps::AbstractVector{<:StatsSpec};
+function proceed(sps::Vector{<:StatsSpec};
         verbose::Bool=false, keep=nothing, keepall::Bool=false, pause::Int=0)
     nsps = length(sps)
     nsps == 0 && throw(ArgumentError("expect a nonempty vector"))

--- a/src/did.jl
+++ b/src/did.jl
@@ -57,7 +57,7 @@ end
 
 Return a tuple of objects that can be accepted by
 the constructor of [`StatsSpec`](@ref).
-If no [`DiffinDiffsEstimator`](@ref) is found in `ntargs`,
+If no [`DiffinDiffsEstimator`](@ref) is found in `args`,
 try to select one based on other information.
 
 This function is required for `@specset` to work properly.
@@ -114,7 +114,7 @@ The order of the arguments is irrelevant.
 # Arguments
 - `[option option=val ...]`: optional settings for @did including keyword arguments passed to an instance of [`StatsSpec`](@ref).
 - `name::AbstractString`: an optional name for the [`StatsSpec`](@ref).
-- `args... kwargs...`: a list of arguments to be processed by [`parse_didargs`](@ref) and [`valid_didargs`](@ref).
+- `args... kwargs...`: a list of arguments to be processed by [`parse_didargs!`](@ref) and [`valid_didargs`](@ref).
 
 # Notes
 When expanded outside [`@specset`](@ref),

--- a/src/did.jl
+++ b/src/did.jl
@@ -12,16 +12,16 @@ Default difference-in-differences estimator selected based on the context.
 """
 const DefaultDID = DiffinDiffsEstimator{:DefaultDID, Tuple{}}
 
-_argpair(arg::Type{<:DiffinDiffsEstimator}) = :d => arg
-_argpair(arg::AbstractString) = :name => String(arg)
-_argpair(arg::AbstractTreatment) = :tr => arg
-_argpair(arg::AbstractParallel) = :pr => arg
-_argpair(::Any) = throw(ArgumentError("unacceptable positional arguments"))
+_key(::Type{<:DiffinDiffsEstimator}) = :d
+_key(::AbstractString) = :name
+_key(::AbstractTreatment) = :tr
+_key(::AbstractParallel) = :pr
+_key(::Any) = throw(ArgumentError("unacceptable positional arguments"))
 
 """
-    parse_didargs(args...; kwargs...)
+    parse_didargs!(args::Vector{Any}, kwargs::Dict{Symbol,Any})
 
-Return a `NamedTuple` that is suitable for being passed to
+Return a `Dict` that is suitable for being passed to
 [`valid_didargs`](@ref) for further processing.
 
 Any [`TreatmentTerm`](@ref) or [`FormulaTerm`](@ref) in `args` is decomposed.
@@ -31,31 +31,29 @@ The order of positional arguments is irrelevant.
 
 This function is required for `@specset` to work properly.
 """
-function parse_didargs(args...; kwargs...)
-    pargs = Pair{Symbol,Any}[kwargs...]
+function parse_didargs!(args::Vector{Any}, kwargs::Dict{Symbol,Any})
     for arg in args
         if arg isa FormulaTerm
             treat, intacts, xs = parse_treat(arg)
-            push!(pargs, _argpair(treat.tr), _argpair(treat.pr))
-            push!(pargs, :yterm => arg.lhs, :treatname => treat.sym)
-            intacts==() || push!(pargs, :treatintterms => intacts)
-            xs==() || push!(pargs, :xterms => xs)
+            kwargs[_key(treat.tr)] = treat.tr
+            kwargs[_key(treat.pr)] = treat.pr
+            kwargs[:yterm] = arg.lhs
+            kwargs[:treatname] = treat.sym
+            intacts==() || (kwargs[:treatintterms] = intacts)
+            xs==() || (kwargs[:xterms] = xs)
         elseif arg isa TreatmentTerm
-            push!(pargs, _argpair(arg.tr), _argpair(arg.pr))
-            push!(pargs, :treatname => arg.sym)
+            kwargs[_key(arg.tr)] = arg.tr
+            kwargs[_key(arg.pr)] = arg.pr
+            kwargs[:treatname] = arg.sym
         else
-            push!(pargs, _argpair(arg))
+            kwargs[_key(arg)] = arg
         end
     end
-    keyargs = first.(pargs)
-    length(keyargs) != length(unique(keyargs)) &&
-        throw(ArgumentError("redundant arguments encountered"))
-    ntargs = (; pargs...)
-    return ntargs
+    return kwargs
 end
 
 """
-    valid_didargs(ntargs::NamedTuple)
+    valid_didargs(args::Dict{Symbol,Any})
 
 Return a tuple of objects that can be accepted by
 the constructor of [`StatsSpec`](@ref).
@@ -64,20 +62,18 @@ try to select one based on other information.
 
 This function is required for `@specset` to work properly.
 """
-function valid_didargs(ntargs::NamedTuple)
-    if haskey(ntargs, :tr) && haskey(ntargs, :pr)
-        d = haskey(ntargs, :d) ? ntargs.d : DefaultDID
-        return valid_didargs(d, ntargs.tr, ntargs.pr, ntargs)
+function valid_didargs(args::Dict{Symbol,Any})
+    if haskey(args, :tr) && haskey(args, :pr)
+        d = pop!(args, :d, DefaultDID)
+        return valid_didargs(d, args[:tr], args[:pr], args)
     else
         throw(ArgumentError("not all required arguments are specified"))
     end
 end
 
 valid_didargs(d::Type{<:DiffinDiffsEstimator},
-    tr::AbstractTreatment, pr::AbstractParallel, ::NamedTuple) =
+    tr::AbstractTreatment, pr::AbstractParallel, ::Dict{Symbol,Any}) =
         error(d.instance, " is not implemented for $(typeof(tr)) and $(typeof(pr))")
-
-_didargs(args...; kwargs...) = valid_didargs(parse_didargs(args...; kwargs...))
 
 """
     didspec(args...; kwargs...)
@@ -85,7 +81,14 @@ _didargs(args...; kwargs...) = valid_didargs(parse_didargs(args...; kwargs...))
 Construct a [`StatsSpec`](@ref) for difference-in-differences
 with the specified arguments.
 """
-didspec(args...; kwargs...) = StatsSpec(_didargs(args...; kwargs...)...)
+function didspec(args...; kwargs...)
+    args = Any[args...]
+    kwargs = Dict{Symbol,Any}(kwargs...)
+    return didspec(args, kwargs)
+end
+
+didspec(args::Vector{Any}, kwargs::Dict{Symbol,Any}) =
+    StatsSpec(valid_didargs(parse_didargs!(args, kwargs))...)
 
 function _show_args(io::IO, sp::StatsSpec{<:DiffinDiffsEstimator})
     if haskey(sp.args, :tr) || haskey(sp.args, :pr)
@@ -96,7 +99,9 @@ function _show_args(io::IO, sp::StatsSpec{<:DiffinDiffsEstimator})
 end
 
 function did(args...; verbose::Bool=false, keep=nothing, keepall::Bool=false, kwargs...)
-    sp = didspec(args...; kwargs...)
+    args = Any[args...]
+    kwargs = Dict{Symbol,Any}(kwargs...)
+    sp = didspec(args, kwargs)
     return sp(verbose=verbose, keep=keep, keepall=keepall)
 end
 
@@ -151,9 +156,9 @@ macro did(args...)
     end
     dargs, dkwargs = _args_kwargs(didargs)
     if noproceed
-        return :(StatsSpec(valid_didargs(parse_didargs($(esc.(dargs)...); $(esc.(dkwargs)...)))...))
+        return :(StatsSpec(valid_didargs(parse_didargs!($(esc(dargs)), $(esc(dkwargs))))...))
     else
-        return :(StatsSpec(valid_didargs(parse_didargs($(esc.(dargs)...); $(esc.(dkwargs)...)))...)(; $(esc(options))...))
+        return :(StatsSpec(valid_didargs(parse_didargs!($(esc(dargs)), $(esc(dkwargs))))...)(; $(esc(options))...))
     end
 end
 

--- a/src/procedures.jl
+++ b/src/procedures.jl
@@ -97,7 +97,7 @@ function checkvars!(data, tr::AbstractTreatment, pr::AbstractParallel,
 
     overlap!(esample, tr_rows, tr, pr, treatname, data)
     sum(esample) == 0 && error("no nonmissing data")
-    return (esample=esample, tr_rows=tr_rows)
+    return (esample=esample, tr_rows=tr_rows::BitVector)
 end
 
 """

--- a/test/StatsProcedures.jl
+++ b/test/StatsProcedures.jl
@@ -369,10 +369,31 @@ end
     end
     @test proceed(s0) == ["a1a1b", "a1a1b1", "a2a2b", "a2a2b1", "a3a3b", "a3a3b1"]
 
+    s1 = @specset [noproceed] begin
+        i = 1
+        a = "a"*string(i)
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:a=>a, :b=>"b")))...)(;)
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:a=>a, :b=>"b1")))...)(;)
+        for i in 2:3
+            a = "a"*string(i)
+            StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:a=>a, :b=>"b")))...)(;)
+            StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:a=>a, :b=>"b1")))...)(;)
+        end
+    end
+    @test s1 == s0
+
     r = @specset for i in 1:3
         a = "a"*string(i)
         StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:a=>a, :b=>"b")))...)(;)
         StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:a=>a, :b=>"b1")))...)(;)
     end
     @test r == ["a1a1b", "a1a1b1", "a2a2b", "a2a2b1", "a3a3b", "a3a3b1"]
+
+    r = @specset RP a="a1" begin
+        StatsSpec(testformatter(testparser(Any[], Dict{Symbol,Any}(:b=>"b")))...)(;)
+        for i in 2:3
+            StatsSpec(testformatter(testparser(Any[], Dict{Symbol,Any}(:a=>"a"*"$i", :b=>"b")))...)(;)
+        end
+    end
+    @test r == ["a1a1b", "a2a2b", "a3a3b"]
 end

--- a/test/StatsProcedures.jl
+++ b/test/StatsProcedures.jl
@@ -1,4 +1,4 @@
-using DiffinDiffsBase: _f, _get, groupargs, _get_default,
+using DiffinDiffsBase: _f, _get, groupargs,
     _sharedby, _show_args, _args_kwargs, _parse!, pool, proceed
 import DiffinDiffsBase: required, default, transformed, combinedargs, copyargs
 
@@ -123,12 +123,6 @@ const ap = AP()
         NullProcedure (TestProcedure with 0 step)"""
 end
 
-@testset "_get_default" begin
-    @test _get_default(rp, NamedTuple()) == (a="a", b="b")
-    @test _get_default(rp, (a="a1",)) == (a="a1", b="b")
-    @test _get_default(rp, (c="c",)) == (a="a", b="b", c="c")
-end
-
 @testset "SharedStatsStep" begin
     s1 = SharedStatsStep(TestRegStep(), 1)
     s2 = SharedStatsStep(TestRegStep(), [3,2])
@@ -250,17 +244,17 @@ end
     @test _show_args(stdout, s1) === nothing
 end
 
-function testparser(args...; kwargs...)
-    pargs = Pair{Symbol,Any}[kwargs...]
+function testparser(args, kwargs)
+    kwargs = Dict{Symbol,Any}(kwargs...)
     for arg in args
         if arg isa Type{<:AbstractStatsProcedure}
-            push!(pargs, :p=>arg)
+            kwargs[:p] = arg
         end
     end
-    return (; pargs...)
+    return kwargs
 end
 
-testformatter(nt::NamedTuple) = (haskey(nt, :name) ? nt.name : "", nt.p, (a=nt.a, b=nt.b))
+testformatter(arg::Dict{Symbol,Any}) = (get(arg, :name, ""), arg[:p], (a=arg[:a], b=arg[:b]))
 
 @testset "proceed" begin
     s1 = StatsSpec("s1", RP, (a="a", b="b"))
@@ -328,78 +322,57 @@ end
 
 @testset "@specset" begin
     s = @specset [noproceed=true] a="a0" begin
-        StatsSpec(testformatter(testparser(RP; a="a1", b="b"))...)(;) end
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:a=>"a1", :b=>"b")))...)(;) end
     @test s == StatsSpec[StatsSpec("", RP, (a="a1", b="b"))]
     @test proceed(s) == ["a1a1b"]
     
     s = @specset [noproceed] a="a0" begin
-        StatsSpec(testformatter(testparser(RP; b="b"))...)(;) end
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:b=>"b")))...)(;) end
     @test s == StatsSpec[StatsSpec("", RP, (a="a0", b="b"))]
     @test proceed(s) == ["a0a0b"]
 
     s = @specset [noproceed] a="a0" b="b0" begin
-        StatsSpec(testformatter(testparser(RP))...)
-        StatsSpec(testformatter(testparser(RP; a="a1", b="b1"))...)(;)
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}()))...)
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:a=>"a1", :b=>"b1")))...)(;)
     end
     @test s == StatsSpec[StatsSpec("", RP, (a="a0", b="b0")), StatsSpec("", RP, (a="a1", b="b1"))]
     @test proceed(s) == ["a0a0b0", "a1a1b1"]
 
     s = @specset [noproceed] a="a0" b="b0" begin
-        StatsSpec(testformatter(testparser(RP))...)(;)
-        StatsSpec(testformatter(testparser(RP; a="a1", c="c"))...)
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}()))...)(;)
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:a=>"a1", :c=>"c")))...)
     end
     @test s == StatsSpec[StatsSpec("", RP, (a="a0", b="b0")), StatsSpec("", RP, (a="a1", b="b0"))]
     @test proceed(s) == ["a0a0b0", "a1a1b0"]
 
     a = "a0"
     r = @specset [verbose keepall] a=a begin
-        StatsSpec(testformatter(testparser(RP; b="b"))...) end
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:b=>"b")))...) end
     @test r == [(a="a0", b="b", c="a0b", result="a0a0b")]
 
     r = @specset [verbose keep=:a] a=a begin
-        StatsSpec(testformatter(testparser(RP; b="b"))...) end
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:b=>"b")))...) end
     @test r == [(a="a0", result="a0a0b")]
 
     r = @specset [verbose keep=[:a]] a=a begin
-        StatsSpec(testformatter(testparser(RP; b="b"))...) end
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:b=>"b")))...) end
     @test r == [(a="a0", result="a0a0b")]
 
     r = @specset [verbose pause=1] a=a begin
-        StatsSpec(testformatter(testparser(RP; b="b"))...) end
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:b=>"b")))...) end
     @test r == ["b"]
     
     s0 = @specset [noproceed] for i in 1:3
         a = "a"*string(i)
-        StatsSpec(testformatter(testparser(RP; a=a, b="b"))...)(;)
-        StatsSpec(testformatter(testparser(RP; a=a, b="b1"))...)(;)
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:a=>a, :b=>"b")))...)(;)
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:a=>a, :b=>"b1")))...)(;)
     end
     @test proceed(s0) == ["a1a1b", "a1a1b1", "a2a2b", "a2a2b1", "a3a3b", "a3a3b1"]
 
-    s1 = @specset [noproceed] begin
-        i = 1
-        a = "a"*string(i)
-        StatsSpec(testformatter(testparser(RP; a=a, b="b"))...)(;)
-        StatsSpec(testformatter(testparser(RP; a=a, b="b1"))...)(;)
-        for i in 2:3
-            a = "a"*string(i)
-            StatsSpec(testformatter(testparser(RP; a=a, b="b"))...)(;)
-            StatsSpec(testformatter(testparser(RP; a=a, b="b1"))...)(;)
-        end
-    end
-    @test s1 == s0
-
     r = @specset for i in 1:3
         a = "a"*string(i)
-        StatsSpec(testformatter(testparser(RP; a=a, b="b"))...)(;)
-        StatsSpec(testformatter(testparser(RP; a=a, b="b1"))...)(;)
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:a=>a, :b=>"b")))...)(;)
+        StatsSpec(testformatter(testparser(Any[RP], Dict{Symbol,Any}(:a=>a, :b=>"b1")))...)(;)
     end
     @test r == ["a1a1b", "a1a1b1", "a2a2b", "a2a2b1", "a3a3b", "a3a3b1"]
-
-    r = @specset RP a="a1" begin
-        StatsSpec(testformatter(testparser(; b="b"))...)(;)
-        for i in 2:3
-            StatsSpec(testformatter(testparser(; a="a"*"$i", b="b"))...)(;)
-        end
-    end
-    @test r == ["a1a1b", "a2a2b", "a3a3b"]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using DataFrames
 using DiffinDiffsBase: @fieldequal, unpack, @unpack, hastreat, parse_treat,
     hasintercept, omitsintercept, isintercept, isomitsintercept, parse_intercept,
     _f, groupargs, copyargs, pool, checkdata, checkvars!, makeweights,
-    _getsubcolumns, parse_didargs, _treatnames
+    _getsubcolumns, parse_didargs!, _treatnames
 using StatsBase: Weights, UnitWeights
 using StatsModels: termvars
 using TypedTables: Table


### PR DESCRIPTION
Converting arguments into a `NamedTuple` takes extra compile time every time the order of how arguments are specified changes or the type of any argument changes. This makes `parse_didargs` slow every time the arguments are specified in a different way.

With the changes made here, generating the `NamedTuple` won't happen until `valid_didargs` when the names of arguments needed are known. Since a dictionary is used, changes in the order of arguments (including replacing formula with manual specifications) won't invoke recompilation when converting to `NamedTuple`. The recompilation still cannot be avoided if the concrete type of any argument changes.