### PR TITLE
Replace Terms with TermSet and allow grouping args by isequal

### DIFF
--- a/src/DiffinDiffsBase.jl
+++ b/src/DiffinDiffsBase.jl
@@ -12,7 +12,7 @@ using Tables: istable, getcolumn, columntable, columnnames
 import Base: ==, show, union
 import Base: eltype, firstindex, lastindex, getindex, iterate, length, sym_in
 import StatsBase: coef, vcov, responsename, coefnames, weights, nobs, dof_residual
-import StatsModels: termvars, hasintercept, omitsintercept
+import StatsModels: termvars
 
 const TimeType = Int
 

--- a/src/DiffinDiffsBase.jl
+++ b/src/DiffinDiffsBase.jl
@@ -46,7 +46,7 @@ export cb,
        notyettreated,
        istreated,
 
-       Terms,
+       TermSet,
        eachterm,
        TreatmentTerm,
        treat,
@@ -60,6 +60,7 @@ export cb,
        @specset,
 
        CheckData,
+       GroupTerms,
        CheckVars,
        MakeWeights,
 

--- a/test/StatsProcedures.jl
+++ b/test/StatsProcedures.jl
@@ -3,29 +3,29 @@ using DiffinDiffsBase: _f, _get, groupargs,
 import DiffinDiffsBase: required, default, transformed, combinedargs, copyargs
 
 testvoidstep(a::String) = NamedTuple()
-const TestVoidStep = StatsStep{:TestVoidStep, typeof(testvoidstep)}
+const TestVoidStep = StatsStep{:TestVoidStep, typeof(testvoidstep), true}
 required(::TestVoidStep) = (:a,)
 
 testregstep(a::String, b::String) = (c=a*b,)
-const TestRegStep = StatsStep{:TestRegStep, typeof(testregstep)}
+const TestRegStep = StatsStep{:TestRegStep, typeof(testregstep), true}
 default(::TestRegStep) = (a="a", b="b")
 
 testlaststep(a::String, c::String) = (result=a*c,)
-const TestLastStep = StatsStep{:TestLastStep, typeof(testlaststep)}
+const TestLastStep = StatsStep{:TestLastStep, typeof(testlaststep), true}
 default(::TestLastStep) = (a="a",)
 transformed(::TestLastStep, ntargs::NamedTuple) = (ntargs.c,)
 
 testcombinestep(a::String, bs::String...) = (c=collect(bs),)
-const TestCombineStep = StatsStep{:TestCombineStep, typeof(testcombinestep)}
+const TestCombineStep = StatsStep{:TestCombineStep, typeof(testcombinestep), true}
 default(::TestCombineStep) = (a="a",)
 combinedargs(::TestCombineStep, ntargs) = [nt.b for nt in ntargs]
 
 testarraystep(a::String, c::Array) = (result=c,)
-const TestArrayStep = StatsStep{:TestArrayStep, typeof(testarraystep)}
+const TestArrayStep = StatsStep{:TestArrayStep, typeof(testarraystep), true}
 required(::TestArrayStep) = (:a, :c)
 copyargs(::TestArrayStep) = (2,)
 
-const TestUnnamedStep = StatsStep{:TestUnnamedStep, typeof(testregstep)}
+const TestUnnamedStep = StatsStep{:TestUnnamedStep, typeof(testregstep), true}
 
 @testset "StatsStep" begin
     @testset "_get" begin

--- a/test/did.jl
+++ b/test/did.jl
@@ -40,7 +40,7 @@ end
     @test args == Dict{Symbol,Any}(pairs((d=TestDID, tr=TR, pr=PR, name="test", treatname=:g)))
 
     args0 = parse_didargs!([TestDID, term(:y) ~ testterm, "test"], Dict{Symbol,Any}())
-    @test args0 == Dict{Symbol,Any}(pairs((d=TestDID, tr=TR, pr=PR, name="test", yterm=term(:y), treatname=:g)))
+    @test args0 == Dict{Symbol,Any}(pairs((d=TestDID, tr=TR, pr=PR, name="test", yterm=term(:y), treatname=:g, treatintterms=TermSet(), xterms=TermSet())))
 
     args1 = parse_didargs!([TestDID, "test", @formula(y ~ treat(g, ttreat(t, 0), tpara(0)))],
         Dict{Symbol,Any}())
@@ -48,7 +48,9 @@ end
 
     args0 = parse_didargs!([TestDID, term(:y) ~ testterm & term(:z) + term(:x)],
         Dict{Symbol,Any}())
-    @test args0 == Dict{Symbol,Any}(pairs((d=TestDID, tr=TR, pr=PR, yterm=term(:y), treatname=:g, treatintterms=(term(:z),), xterms=(term(:x),))))
+    @test args0 == Dict{Symbol,Any}(pairs((d=TestDID, tr=TR, pr=PR, yterm=term(:y),
+        treatname=:g, treatintterms=TermSet(term(:z)=>nothing),
+        xterms=TermSet(term(:x)=>nothing))))
     
     args1 = parse_didargs!([TestDID,
         @formula(y ~ treat(g, ttreat(t, 0), tpara(0)) & z + x)], Dict{Symbol,Any}())
@@ -144,8 +146,8 @@ end
     @test sp5 ≊ sp4
     @test sp4 ≊ @did [noproceed] TestDID testterm "name"
 
-    sp6 = StatsSpec("", TestDID, (tr=TR, pr=PR, 
-        yterm=term(:y), treatname=:g, treatintterms=(term(:z),), xterms=(term(:x),)))
+    sp6 = StatsSpec("", TestDID, (tr=TR, pr=PR, yterm=term(:y), treatname=:g,
+        treatintterms=TermSet(term(:z)=>nothing), xterms=TermSet(term(:x)=>nothing)))
     sp7 = didspec(TestDID, term(:y) ~ testterm & term(:z) + term(:x))
     sp8 = didspec(TestDID, @formula(y ~ treat(g, ttreat(t, 0), tpara(0)) & z + x))
     @test sp7 ≊ sp6
@@ -212,14 +214,15 @@ end
     @test did(TestDID, testterm; keepall=true) == d
 
     d0 = @did [keepall] TestDID term(:y) ~ testterm
-    @test d0 ≊ merge(d, (yterm=term(:y),))
+    @test d0 ≊ merge(d, (yterm=term(:y), treatintterms=TermSet(), xterms=TermSet()))
     @test did(TestDID, term(:y) ~ testterm; keepall=true) == d0
     d1 = @did [keepall] TestDID @formula(y ~ treat(g, ttreat(t, 0), tpara(0))) "test"
     @test d1 ≊ d0
     @test did(TestDID, @formula(y ~ treat(g, ttreat(t, 0), tpara(0))); keepall=true) == d1
 
     d0 = @did [keepall] TestDID term(:y) ~ testterm & term(:z) + term(:x)
-    @test d0 ≊ merge(d, (yterm=term(:y), treatintterms=(term(:z),), xterms=(term(:x),)))
+    @test d0 ≊ merge(d, (yterm=term(:y), treatintterms=TermSet(term(:z)=>nothing),
+        xterms=TermSet(term(:x)=>nothing)))
     @test did(TestDID, term(:y) ~ testterm & term(:z) + term(:x); keepall=true) == d0
     d1 = @did [keepall] "test" TestDID @formula(y ~ treat(g, ttreat(t, 0), tpara(0)) & z + x)
     @test d1 ≊ d0
@@ -274,7 +277,8 @@ end
         @did [noproceed] TestDID @formula(y ~ treat(g, ttreat(t, 0), tpara(0)))
     end
     @test s[1] ≊ didspec(TestDID, TR, PR; treatname=:g)
-    @test s[2] ≊ didspec(TestDID, TR, PR; yterm=term(:y), treatname=:g)
+    @test s[2] ≊ didspec(TestDID, TR, PR; yterm=term(:y), treatname=:g,
+        treatintterms=TermSet(), xterms=TermSet())
 
     s = @specset [noproceed] for i in 1:2
         @did "name"*"$i" TestDID TR PR a=i

--- a/test/did.jl
+++ b/test/did.jl
@@ -31,6 +31,10 @@ end
 end
 
 @testset "parse_didargs!" begin
+    args = Dict{Symbol,Any}(:xterms=>(term(:x),))
+    _totermset!(args, :xterms)
+    @test args[:xterms] == TermSet(term(:x)=>nothing)
+
     @test parse_didargs!(Any["test"], Dict{Symbol,Any}()) == Dict{Symbol,Any}(:name=>"test")
 
     args = parse_didargs!([TestDID, TR, PR], Dict{Symbol,Any}(:a=>1, :b=>2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,8 +3,8 @@ using DiffinDiffsBase
 
 using DataFrames
 using DiffinDiffsBase: @fieldequal, unpack, @unpack, hastreat, parse_treat,
-    hasintercept, omitsintercept, isintercept, isomitsintercept, parse_intercept,
-    _f, groupargs, copyargs, pool, checkdata, checkvars!, makeweights,
+    hasintercept, omitsintercept, isintercept, isomitsintercept, parse_intercept!,
+    _f, _byid, groupargs, copyargs, pool, checkdata, groupterms, checkvars!, makeweights,
     _getsubcolumns, parse_didargs!, _treatnames
 using StatsBase: Weights, UnitWeights
 using StatsModels: termvars

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,9 +3,9 @@ using DiffinDiffsBase
 
 using DataFrames
 using DiffinDiffsBase: @fieldequal, unpack, @unpack, hastreat, parse_treat,
-    hasintercept, omitsintercept, isintercept, isomitsintercept, parse_intercept!,
+    isintercept, isomitsintercept, parse_intercept!,
     _f, _byid, groupargs, copyargs, pool, checkdata, groupterms, checkvars!, makeweights,
-    _getsubcolumns, parse_didargs!, _treatnames
+    _getsubcolumns, _totermset!, parse_didargs!, _treatnames
 using StatsBase: Weights, UnitWeights
 using StatsModels: termvars
 using TypedTables: Table

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -22,11 +22,11 @@ tpara(c::ConstantTerm) = TestParallel{ParallelCondition,ParallelStrength}(c.n)
 
 teststep(tr::AbstractTreatment, pr::AbstractParallel) =
     (str=sprint(show, tr), spr=sprint(show, pr))
-const TestStep = StatsStep{:TestStep, typeof(teststep)}
+const TestStep = StatsStep{:TestStep, typeof(teststep), true}
 required(::TestStep) = (:tr, :pr)
 
 testnextstep(::AbstractTreatment, str::String) = (next="next"*str,)
-const TestNextStep = StatsStep{:TestNextStep, typeof(testnextstep)}
+const TestNextStep = StatsStep{:TestNextStep, typeof(testnextstep), true}
 required(::TestNextStep) = (:tr, :str)
 
 const TestDID = DiffinDiffsEstimator{:TestDID, Tuple{TestStep,TestNextStep}}


### PR DESCRIPTION
Working with tuples of terms results in excessive compilation. Replacing `Terms` (based on `Tuple`) with `TermSet` (based on `IdDict`) helps avoid some compilation arising from changes of specifications. Additionally, it is no longer necessary to specify terms in tuples. Using some other container such as a `Vector` further reduces the amount of type inference. However, the order of how terms are specified is no longer preserved.

`StatsStep` now has an additional parameter that indicates whether arguments should be grouped by `objectid` or `isequal` for `proceed`. The new procedure `GroupTerms` requires grouping by `isequal` for collecting `TermSet`s containing the same terms.