### PR TITLE
Add a table type SubColumns that replaces _getsubcolumns

### DIFF
--- a/src/DiffinDiffsBase.jl
+++ b/src/DiffinDiffsBase.jl
@@ -7,7 +7,8 @@ using Missings: disallowmissing
 using Reexport
 using StatsBase: Weights, uweights
 @reexport using StatsModels
-using Tables: istable, getcolumn, columntable, columnnames
+using Tables
+using Tables: istable, columnnames, getcolumn
 
 import Base: ==, show, union
 import Base: eltype, firstindex, lastindex, getindex, iterate, length, sym_in
@@ -51,6 +52,8 @@ export cb,
        TreatmentTerm,
        treat,
 
+       SubColumns,
+
        StatsStep,
        AbstractStatsProcedure,
        SharedStatsStep,
@@ -77,6 +80,7 @@ include("utils.jl")
 include("treatments.jl")
 include("parallels.jl")
 include("terms.jl")
+include("SubColumns.jl")
 include("StatsProcedures.jl")
 include("procedures.jl")
 include("did.jl")

--- a/src/SubColumns.jl
+++ b/src/SubColumns.jl
@@ -1,0 +1,97 @@
+struct SubColumns
+    columns::Vector{AbstractVector}
+    names::Vector{Symbol}
+    lookup::Dict{Symbol,Int}
+    # The inner constructor resolves method ambiguity
+    SubColumns(columns::Vector{AbstractVector}, names::Vector{Symbol}, 
+        lookup::Dict{Symbol,Int}) = new(columns, names, lookup)
+end
+
+"""
+    SubColumns(data, names, rows=Colon(); nomissing=true)
+
+Construct a column table from `data` using columns specified with `names` over selected `rows`.
+
+By default, columns are converted to drop support for missing values.
+When possible, resulting columns share memory with original columns.
+"""
+function SubColumns(data, names, rows=Colon(); nomissing=true)
+    Tables.istable(data) || throw(ArgumentError("data must support Tables.jl interface"))
+    names = names isa Vector{Symbol} ? names : Symbol[names...]
+    ncol = length(names)
+    columns = Vector{AbstractVector}(undef, ncol)
+    lookup = Dict{Symbol,Int}()
+    if ncol > 0
+        @inbounds for i in 1:ncol
+            col = view(getcolumn(data, names[i]), rows)
+            nomissing && (col = disallowmissing(col))
+            columns[i] = col
+            lookup[names[i]] = i
+        end
+    end
+    return SubColumns(columns, names, lookup)
+end
+
+SubColumns(data, names::Symbol, rows=Colon(); nomissing=true) =
+    SubColumns(data, [names], rows, nomissing=nomissing)
+
+_columns(cols::SubColumns) = getfield(cols, :columns)
+_names(cols::SubColumns) = getfield(cols, :names)
+_lookup(cols::SubColumns) = getfield(cols, :lookup)
+
+ncol(cols::SubColumns) = length(_names(cols))
+nrow(cols::SubColumns) = ncol(cols) > 0 ? length(_columns(cols)[1])::Int : 0
+
+Base.size(cols::SubColumns) = (nrow(cols), ncol(cols))
+function Base.size(cols::SubColumns, i::Integer)
+    if i == 1
+        nrow(cols)
+    elseif i == 2
+        ncol(cols)
+    else
+        throw(ArgumentError("SubColumns only have two dimensions"))
+    end
+end
+
+Base.isempty(cols::SubColumns) = size(cols, 1) == 0 || size(cols, 2) == 0
+
+@inline function Base.getindex(cols::SubColumns, i)
+    @boundscheck if !checkindex(Bool, axes(_columns(cols), 1), i)
+        throw(BoundsError(cols, i))
+    end
+    @inbounds return _columns(cols)[i]
+end
+
+@inline Base.getindex(cols::SubColumns, n::Symbol) = cols[_lookup(cols)[n]]
+@inline Base.getproperty(cols::SubColumns, n::Symbol) = cols[n]
+Base.propertynames(cols::SubColumns) = copy(_names(cols))
+
+function Base.:(==)(x::SubColumns, y::SubColumns)
+    size(x) == size(y) || return false
+    _names(x) == _names(y) || return false
+    eq = true
+    for i in 1:size(x, 2)
+        # missing could arise
+        coleq = x[i] == y[i]
+        isequal(coleq, false) && return false
+        eq &= coleq
+    end
+    return eq
+end
+
+Base.show(io::IO, cols::SubColumns) = print(io, nrow(cols), '×', ncol(cols), " SubColumns")
+
+function Base.show(io::IO, ::MIME"text/plain", cols::SubColumns)
+    show(io, cols)
+    ncol(cols) > 0 && print(io, ":\n  ", join(propertynames(cols), ' '))
+end
+
+Base.summary(cols::SubColumns) = string(nrow(cols), '×', ncol(cols), ' ', nameof(typeof(cols)))
+Base.summary(io::IO, cols::SubColumns) = print(io, summary(cols))
+
+Tables.istable(::Type{SubColumns}) = true
+Tables.columnaccess(::Type{SubColumns}) = true
+Tables.columns(cols::SubColumns) = cols
+
+Tables.getcolumn(cols::SubColumns, i::Int) = cols[i]
+Tables.getcolumn(cols::SubColumns, n::Symbol) = cols[n]

--- a/src/procedures.jl
+++ b/src/procedures.jl
@@ -160,9 +160,3 @@ const MakeWeights = StatsStep{:MakeWeights, typeof(makeweights), true}
 
 required(::MakeWeights) = (:data, :esample)
 default(::MakeWeights) = (weightname=nothing,)
-
-_getsubcolumns(data, name::Symbol, idx=Colon()) =
-    columntable(NamedTuple{(name,)}((disallowmissing(view(getcolumn(data, name), idx)),)))
-
-_getsubcolumns(data, names, idx=Colon()) = columntable(NamedTuple{(names...,)}(
-    map(n->disallowmissing(view(getcolumn(data, n), idx)), names)))

--- a/test/SubColumns.jl
+++ b/test/SubColumns.jl
@@ -1,0 +1,58 @@
+@testset "SubColumns" begin
+    hrs = exampledata("hrs")
+    df = DataFrame(hrs)
+    allowmissing!(df)
+
+    cols = SubColumns(df, [])
+    @test size(cols) == (0, 0)
+    @test isempty(cols)
+    @test_throws BoundsError cols[1]
+    @test_throws ArgumentError size(cols, 3)
+    @test sprint(show, MIME("text/plain"), cols) == "0×0 SubColumns"
+
+    cols = SubColumns(df, :wave, falses(size(df,1)))
+    @test size(cols) == (0, 1)
+    @test isempty(cols)
+    @test cols.wave == cols[:wave] == cols[1] == Int[]
+
+    cols = SubColumns(df, :wave)
+    @test cols.wave == hrs.wave
+    @test eltype(cols.wave) == Int
+    @test size(cols) == (3280, 1)
+
+    cols = SubColumns(df, :wave, nomissing=false)
+    @test cols.wave == hrs.wave
+    @test eltype(cols.wave) == Union{Int, Missing}
+
+    df.male .= ifelse.(df.wave.==11, missing, df.male)
+    @test_throws MethodError SubColumns(df, :male)
+
+    cols = SubColumns(df, :male, df.wave.!=11)
+    @test cols.male == hrs.male[hrs.wave.!=11]
+    @test eltype(cols.male) == Int
+
+    cols = SubColumns(df, (:wave, :male), df.wave.!=11)
+    @test cols.wave == hrs.wave[hrs.wave.!=11]
+    @test eltype(cols.wave) == Int
+    names = [:wave, :male]
+    @test SubColumns(df, names, df.wave.!=11) == cols
+    @test cols[1:2] == cols[[1,2]] == getfield(cols, :columns)
+
+    @test propertynames(cols) == names
+    @test propertynames(cols) !== names
+
+    @test sprint(show, cols) == "2624×2 SubColumns"
+    @test sprint(show, MIME("text/plain"), cols) == """
+        2624×2 SubColumns:
+          wave male"""
+    
+    @test summary(cols) == "2624×2 SubColumns"
+    summary(stdout, cols)
+
+    @test Tables.istable(typeof(cols))
+    @test Tables.columnaccess(typeof(cols))
+    @test Tables.columns(cols) === cols
+    col1 = getfield(cols, :columns)[1]
+    @test Tables.getcolumn(cols, 1) === col1
+    @test Tables.getcolumn(cols, :wave) === col1
+end

--- a/test/procedures.jl
+++ b/test/procedures.jl
@@ -136,29 +136,3 @@ end
         @test r.weights isa UnitWeights && sum(r.weights) == size(hrs,1)
     end
 end
-
-@testset "_getsubcolumns" begin
-    hrs = exampledata("hrs")
-    df = DataFrame(hrs)
-    allowmissing!(df)
-    @test _getsubcolumns(df, :wave, falses(size(df,1))).wave == Int[]
-    cols = _getsubcolumns(df, :wave)
-    @test cols.wave == hrs.wave
-    @test eltype(cols.wave) == Int
-    @test _getsubcolumns(df, :wave, df.wave.==10).wave == hrs.wave[hrs.wave.==10]
-
-    df.male .= ifelse.(df.wave.==11, missing, df.male)
-    @test_throws MethodError _getsubcolumns(df, :male)
-    cols = _getsubcolumns(df, :male, df.wave.!=11)
-    @test cols.male == hrs.male[hrs.wave.!=11]
-    @test eltype(cols.male) == Int
-
-    cols = _getsubcolumns(df, (:wave, :oop_spend))
-    @test cols.oop_spend == hrs.oop_spend
-    @test eltype(cols.oop_spend) == Float64
-    @test_throws MethodError _getsubcolumns(df, (:wave, :male))
-    cols = _getsubcolumns(df, (:wave, :male), df.wave.!=11)
-    @test cols.wave == hrs.wave[hrs.wave.!=11]
-    @test eltype(cols.wave) == Int
-    @test _getsubcolumns(df, [:wave, :male], df.wave.!=11) == cols
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using DataFrames
 using DiffinDiffsBase: @fieldequal, unpack, @unpack, hastreat, parse_treat,
     isintercept, isomitsintercept, parse_intercept!,
     _f, _byid, groupargs, copyargs, pool, checkdata, groupterms, checkvars!, makeweights,
-    _getsubcolumns, _totermset!, parse_didargs!, _treatnames
+    _totermset!, parse_didargs!, _treatnames
 using StatsBase: Weights, UnitWeights
 using StatsModels: termvars
 using TypedTables: Table
@@ -20,6 +20,7 @@ const tests = [
     "terms",
     "treatments",
     "parallels",
+    "SubColumns",
     "StatsProcedures",
     "procedures",
     "did"


### PR DESCRIPTION
Whenever any name or order of columns provided to `_getsubcolumns` changes, the function needs to be recompiled as the returned table is based on `NamedTuple`.

`SubColumns` avoids such recompilation as it collects columns and names in `Vector`s and lookups a column by name through a `Dict`. Such a design mostly follows `DataFrames.DataFrame`.
