### PR TITLE
Add ScaledArray, RotatingTimeValue and settime

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,8 +37,7 @@ julia = "1.3"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DataFrames", "Dates", "Test"]
+test = ["DataFrames", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
@@ -36,7 +37,8 @@ julia = "1.3"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DataFrames", "Test"]
+test = ["DataFrames", "Dates", "Test"]

--- a/src/DiffinDiffsBase.jl
+++ b/src/DiffinDiffsBase.jl
@@ -5,6 +5,7 @@ using CSV
 using CodecZlib: GzipDecompressorStream
 using Combinatorics: combinations
 using DataAPI: refarray, refpool, invrefpool
+using Dates: Period, TimeType
 using LinearAlgebra: Diagonal
 using MacroTools: @capture, isexpr, postwalk
 using Missings: allowmissing, disallowmissing
@@ -15,15 +16,13 @@ using StatsFuns: tdistccdf, tdistinvcdf
 @reexport using StatsModels
 using StatsModels: Schema
 using Tables
-using Tables: AbstractColumns, table, istable, columnnames, getcolumn
+using Tables: AbstractColumns, istable, columnnames, getcolumn
 
-import Base: ==, show, parent, view, diff
+import Base: ==, -, isless, show, parent, view, diff
 import Base: eltype, firstindex, lastindex, getindex, iterate, length, sym_in
 import StatsBase: coef, vcov, confint, nobs, dof_residual, responsename, coefnames, weights,
     coeftable
 import StatsModels: concrete_term, schema, termvars, lag, lead
-
-const TimeType = Int
 
 # Reexport objects from StatsBase
 export coef, vcov, stderror, confint, nobs, dof_residual, responsename, coefnames, weights,
@@ -32,6 +31,8 @@ export coef, vcov, stderror, confint, nobs, dof_residual, responsename, coefname
 export cb,
        ≊,
        exampledata,
+       RotatingTimeValue,
+       rotatingtime,
 
        VecColumnTable,
        VecColsRow,

--- a/src/DiffinDiffsBase.jl
+++ b/src/DiffinDiffsBase.jl
@@ -4,6 +4,7 @@ using Base: @propagate_inbounds
 using CSV
 using CodecZlib: GzipDecompressorStream
 using Combinatorics: combinations
+using DataAPI
 using DataAPI: refarray, refpool, invrefpool
 using Dates: Period, TimeType
 using LinearAlgebra: Diagonal
@@ -18,7 +19,7 @@ using StatsModels: Schema
 using Tables
 using Tables: AbstractColumns, istable, columnnames, getcolumn
 
-import Base: ==, -, isless, show, parent, view, diff
+import Base: ==, +, -, *, isless, show, parent, view, diff
 import Base: eltype, firstindex, lastindex, getindex, iterate, length, sym_in
 import StatsBase: coef, vcov, confint, nobs, dof_residual, responsename, coefnames, weights,
     coeftable
@@ -41,6 +42,10 @@ export cb,
        apply_and!,
        apply_and,
        TableIndexedMatrix,
+
+       ScaledArray,
+       ScaledVector,
+       ScaledMatrix,
 
        TreatmentSharpness,
        SharpDesign,
@@ -73,6 +78,7 @@ export cb,
 
        findcell,
        cellrows,
+       settime,
        PanelStructure,
        setpanel,
        findlag!,
@@ -121,6 +127,7 @@ export cb,
 
 include("utils.jl")
 include("tables.jl")
+include("ScaledArrays.jl")
 include("treatments.jl")
 include("parallels.jl")
 include("terms.jl")

--- a/src/ScaledArrays.jl
+++ b/src/ScaledArrays.jl
@@ -1,0 +1,162 @@
+const DEFAULT_REF_TYPE = Int32
+
+# A wrapper only used for resolving method ambiguity when constructing ScaledArray
+mutable struct RefArray{R}
+    a::R
+end
+
+mutable struct ScaledArray{T,N,RA,S,P} <: AbstractArray{T,N}
+    refs::RA
+    start::T
+    step::S
+    stop::T
+    pool::P
+    ScaledArray{T,N,RA,S,P}(rs::RefArray{RA}, start::T, step::S, stop::T,
+        pool::P=start:step:stop) where
+        {T, N, RA<:AbstractArray{<:Any, N}, S, P<:AbstractRange{T}} =
+            new{T,N,RA,S,P}(rs.a, start, step, stop, pool)
+end
+
+ScaledArray(rs::RefArray{RA}, start::T, step::S, stop::T, pool::P=start:step:stop) where
+    {T,RA,S,P} = ScaledArray{T,ndims(RA),RA,S,P}(rs, start, step, stop, pool)
+
+const ScaledVector{T} = ScaledArray{T,1}
+const ScaledMatrix{T} = ScaledArray{T,2}
+
+function _validmin(min, xmin, isstart::Bool)
+    if min === nothing
+        min = xmin
+    elseif min > xmin
+        str = isstart ? "start =" : "stop ="
+        throw(ArgumentError("$str $min is greater than the allowed minimum element $xmin"))
+    end
+    return min
+end
+
+function _validmax(max, xmax, isstart::Bool)
+    if max === nothing
+        max = xmax
+    elseif max < xmax
+        str = isstart ? "start =" : "stop ="
+        throw(ArgumentError("$str $max is smaller than the allowed maximum element $xmax"))
+    end
+    return max
+end
+
+function validstartstepstop(x::AbstractArray, start, step, stop, usepool)
+    step === nothing && throw(ArgumentError("step cannot be nothing"))
+    pool = DataAPI.refpool(x)
+    xmin, xmax = usepool && pool !== nothing ? extrema(pool) : extrema(x)
+    if xmin + step > xmin
+        start = _validmin(start, xmin, true)
+        stop = _validmax(stop, xmax, false)
+    elseif xmin + step < xmin
+        start = _validmax(start, xmax, true)
+        stop = _validmin(stop, xmin, false)
+    else
+        throw(ArgumentError("step cannot be zero"))
+    end
+    T = promote_type(eltype(x), eltype(start:step:stop))
+    return convert(T, start), convert(T, stop)
+end
+
+function _scaledlabel(x::AbstractArray, step, ref_type::Type{<:Signed}=DEFAULT_REF_TYPE;
+        start=nothing, stop=nothing, usepool=true)
+    start, stop = validstartstepstop(x, start, step, stop, usepool)
+    pool = start:step:stop
+    while typemax(ref_type) < length(pool)
+        ref_type = widen(ref_type)
+    end
+    refs = similar(x, ref_type)
+    @inbounds for i in eachindex(refs)
+        refs[i] = length(start:step:x[i])
+    end
+    return refs, start, step, stop
+end
+
+function ScaledArray(x::AbstractArray, ref_type::Type, start, step, stop, usepool=true)
+    refs, start, step, stop = _scaledlabel(x, step, ref_type; start=start, stop=stop, usepool=usepool)
+    return ScaledArray(RefArray(refs), start, step, stop)
+end
+
+function ScaledArray(sa::ScaledArray, ref_type::Type, start, step, stop, usepool=true)
+    if step !== nothing && step != sa.step
+        refs, start, step, stop = _scaledlabel(sa, step, ref_type; start=start, stop=stop, usepool=usepool)
+        return ScaledArray(RefArray(refs), start, step, stop)
+    else
+        step = sa.step
+        start, stop = validstartstepstop(sa, start, step, stop, usepool)
+        refs = similar(sa.refs, ref_type)
+        if start == sa.start
+            copy!(refs, sa.refs)
+        elseif start < sa.start && start < stop || start > sa.start && start > stop
+            offset = length(start:step:sa.start) - 1
+            refs .= sa.refs .+ offset
+        else
+            offset = length(sa.start:step:start) - 1
+            refs .= sa.refs .- offset
+        end
+        return ScaledArray(RefArray(refs), start, step, stop)
+    end
+end
+
+ScaledArray(x::AbstractArray, start, step, stop;
+    ref_type::Type=DEFAULT_REF_TYPE, usepool=true) =
+        ScaledArray(x, ref_type, start, step, stop, usepool)
+
+ScaledArray(sa::ScaledArray, start, step, stop;
+    ref_type::Type=eltype(refarray(sa)), usepool=true) =
+        ScaledArray(sa, ref_type, start, step, stop, usepool)
+
+ScaledArray(x::AbstractArray, step; ref_type::Type=DEFAULT_REF_TYPE,
+    start=nothing, stop=nothing, usepool=true) =
+        ScaledArray(x, ref_type, start, step, stop, usepool)
+
+ScaledArray(sa::ScaledArray, step=nothing; ref_type::Type=eltype(refarray(sa)),
+    start=nothing, stop=nothing, usepool=true) =
+        ScaledArray(sa, ref_type, start, step, stop, usepool)
+
+Base.size(sa::ScaledArray) = size(sa.refs)
+Base.IndexStyle(::Type{<:ScaledArray{T,N,RA}}) where {T,N,RA} = IndexStyle(RA)
+
+DataAPI.refarray(sa::ScaledArray) = sa.refs
+DataAPI.refvalue(sa::ScaledArray, n::Integer) = getindex(DataAPI.refpool(sa), n)
+DataAPI.refpool(sa::ScaledArray) = sa.pool
+
+DataAPI.refarray(ssa::SubArray{<:Any, <:Any, <:ScaledArray}) =
+    view(parent(ssa).refs, ssa.indices...)
+DataAPI.refvalue(ssa::SubArray{<:Any, <:Any, <:ScaledArray}, n::Integer) =
+    DataAPI.refvalue(parent(ssa), n)
+DataAPI.refpool(ssa::SubArray{<:Any, <:Any, <:ScaledArray}) =
+    DataAPI.refpool(parent(ssa))
+
+@inline function Base.getindex(sa::ScaledArray, i::Int)
+    refs = DataAPI.refarray(sa)
+    @boundscheck checkbounds(refs, i)
+    @inbounds n = refs[i]
+    pool = DataAPI.refpool(sa)
+    @boundscheck checkbounds(pool, n)
+    return @inbounds pool[n]
+end
+
+@inline function Base.getindex(sa::ScaledArray, I...)
+    refs = DataAPI.refarray(sa)
+    @boundscheck checkbounds(refs, I...)
+    @inbounds ns = refs[I...]
+    pool = DataAPI.refpool(sa)
+    @boundscheck checkbounds(pool, ns)
+    return @inbounds pool[ns]
+end
+
+function Base.:(==)(x::ScaledArray, y::ScaledArray)
+    size(x) == size(y) || return false
+    x.start == y.start && x.step == y.step && return x.refs == y.refs
+    eq = true
+    for (p, q) in zip(x, y)
+        # missing could arise
+        veq = p == q
+        isequal(veq, false) && return false
+        eq &= veq
+    end
+    return eq
+end

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -109,7 +109,7 @@ function cellrows(cols::VecColumnTable, refrows::IdDict)
 end
 
 """
-    PanelStructure{R<:Signed, T1, T2<:TimeType}
+    PanelStructure{R<:Signed, T1, T2<:ValidTimeType}
 
 Panel data structure defined by unique combinations of unit ids and time periods.
 It contains the information required for certain operations such as
@@ -123,7 +123,7 @@ See also [`setpanel`](@ref).
 - `timepool::Vector{T2}`: sorted unique time periods.
 - `laginds::Dict{Int, Vector{Int}}`: a map from lag distances to vectors of indices of lagged values.
 """
-struct PanelStructure{R<:Signed, T1, T2<:TimeType}
+struct PanelStructure{R<:Signed, T1, T2<:ValidTimeType}
     refs::Vector{R}
     invrefs::Dict{R, Int}
     idpool::Vector{T1}
@@ -180,7 +180,7 @@ can be specified with `ref_type`.
 """
 function setpanel(id::AbstractArray, time::AbstractArray, timestep=nothing;
         ref_type::Type{<:Signed}=Int32)
-    eltype(time) <: TimeType ||
+    eltype(time) <: ValidTimeType ||
         throw(ArgumentError("invalid element type $(eltype(time)) from time column"))
     length(id) == length(time) || throw(DimensionMismatch(
         "id has length $(length(id)) while time has length $(length(time))"))

--- a/src/parallels.jl
+++ b/src/parallels.jl
@@ -93,17 +93,17 @@ and a group that did not receive any treatment in any sample period.
 See also [`nevertreated`](@ref).
 
 # Fields
-- `e::Tuple{Vararg{TimeType}}`: group indices for units that did not receive any treatment.
+- `e::Tuple{Vararg{ValidTimeType}}`: group indices for units that did not receive any treatment.
 - `c::C`: an instance of [`ParallelCondition`](@ref).
 - `s::S`: an instance of [`ParallelStrength`](@ref).
 """
 struct NeverTreatedParallel{C,S} <: TrendParallel{C,S}
-    e::Tuple{Vararg{TimeType}}
+    e::Tuple{Vararg{ValidTimeType}}
     c::C
     s::S
     function NeverTreatedParallel(e, c::ParallelCondition, s::ParallelStrength)
-        e = (unique!(sort!([e...]))...,)
-        isempty(e) && error("field `e` cannot be empty") 
+        e = e isa TimeType ? (e,) : (unique!(sort!([e...]))...,)
+        isempty(e) && error("field `e` cannot be empty")
         return new{typeof(c),typeof(s)}(e, c, s)
     end
 end
@@ -168,8 +168,8 @@ and any group that received the treatment relatively late (or never receved).
 See also [`notyettreated`](@ref).
 
 # Fields
-- `e::Tuple{Vararg{TimeType}}`: group indices for units that received the treatment relatively late.
-- `ecut::Tuple{Vararg{TimeType}}`: user-specified period(s) when units in a group in `e` started to receive treatment.
+- `e::Tuple{Vararg{ValidTimeType}}`: group indices for units that received the treatment relatively late.
+- `ecut::Tuple{Vararg{ValidTimeType}}`: user-specified period(s) when units in a group in `e` started to receive treatment.
 - `c::C`: an instance of [`ParallelCondition`](@ref).
 - `s::S`: an instance of [`ParallelStrength`](@ref).
 
@@ -179,16 +179,18 @@ See also [`notyettreated`](@ref).
     - the sample has a rotating panel structure with periods overlapping with some others.
 """
 struct NotYetTreatedParallel{C,S} <: TrendParallel{C,S}
-    e::Tuple{Vararg{TimeType}}
-    ecut::Tuple{Vararg{TimeType}}
+    e::Tuple{Vararg{ValidTimeType}}
+    ecut::Tuple{Vararg{ValidTimeType}}
     c::C
     s::S
     function NotYetTreatedParallel(e, ecut, c::ParallelCondition, s::ParallelStrength)
-        e = (unique!(sort!([e...]))...,)
-        isempty(e) && error("field `e` cannot be empty")
-        ecut = (unique!(sort!([ecut...]))...,)
-        isempty(ecut) && error("field `ecut` cannot be empty")
-        return new{typeof(c),typeof(s)}(e, ecut, c, s)
+        e = e isa TimeType ? (e,) : (unique!(sort!([e...]))...,)
+        isempty(e) && throw(ArgumentError("field e cannot be empty"))
+        ecut = ecut isa TimeType ? (ecut,) : (unique!(sort!([ecut...]))...,)
+        isempty(ecut) && throw(ArgumentError("field ecut cannot be empty"))
+        eltype(e) == eltype(ecut) ||
+            throw(ArgumentError("e and ecut must have the same element type"))
+        return new{typeof(c), typeof(s)}(e, ecut, c, s)
     end
 end
 
@@ -207,7 +209,7 @@ end
 
 """
     notyettreated(e, ecut, c::ParallelCondition, s::ParallelStrength)
-    notyettreated(e, ecut=minimum(e); c=Unconditional(), s=Exact())
+    notyettreated(e, ecut=e; c=Unconditional(), s=Exact())
 
 Construct a [`NotYetTreatedParallel`](@ref) with
 fields set by the arguments.
@@ -239,8 +241,7 @@ Parallel trends with any not-yet-treated group:
 """
 notyettreated(e, ecut, c::ParallelCondition, s::ParallelStrength) =
     NotYetTreatedParallel(e, ecut, c, s)
-notyettreated(e, ecut=minimum(e);
-    c::ParallelCondition=Unconditional(), s::ParallelStrength=Exact()) =
+notyettreated(e, ecut=e; c::ParallelCondition=Unconditional(), s::ParallelStrength=Exact()) =
         NotYetTreatedParallel(e, ecut, c, s)
 
 """

--- a/src/parallels.jl
+++ b/src/parallels.jl
@@ -102,7 +102,7 @@ struct NeverTreatedParallel{C,S} <: TrendParallel{C,S}
     c::C
     s::S
     function NeverTreatedParallel(e, c::ParallelCondition, s::ParallelStrength)
-        e = e isa TimeType ? (e,) : (unique!(sort!([e...]))...,)
+        e = applicable(iterate, e) ? (unique!(sort!([e...]))...,) : (e,)
         isempty(e) && error("field `e` cannot be empty")
         return new{typeof(c),typeof(s)}(e, c, s)
     end
@@ -184,9 +184,9 @@ struct NotYetTreatedParallel{C,S} <: TrendParallel{C,S}
     c::C
     s::S
     function NotYetTreatedParallel(e, ecut, c::ParallelCondition, s::ParallelStrength)
-        e = e isa TimeType ? (e,) : (unique!(sort!([e...]))...,)
+        e = applicable(iterate, e) ? (unique!(sort!([e...]))...,) : (e,)
         isempty(e) && throw(ArgumentError("field e cannot be empty"))
-        ecut = ecut isa TimeType ? (ecut,) : (unique!(sort!([ecut...]))...,)
+        ecut = applicable(iterate, ecut) ? (unique!(sort!([ecut...]))...,) : (ecut,)
         isempty(ecut) && throw(ArgumentError("field ecut cannot be empty"))
         eltype(e) == eltype(ecut) ||
             throw(ArgumentError("e and ecut must have the same element type"))

--- a/src/procedures.jl
+++ b/src/procedures.jl
@@ -1,29 +1,28 @@
 """
     checkdata(args...)
 
-Check `data` is a `Table` and find valid rows for options `subset` and `weightname`.
+Check `data` is `Tables.AbstractColumns`-compatible
+and find valid rows for options `subset` and `weightname`.
 See also [`CheckData`](@ref).
 """
-function checkdata(data, subset::Union{BitVector, Nothing},
-        weightname::Union{Symbol, Nothing})
-
+function checkdata(data, subset::Union{BitVector, Nothing}, weightname::Union{Symbol, Nothing})
     istable(data) ||
-        throw(ArgumentError("expect `data` being a `Table` while receiving a $(typeof(data))"))
-    
+        throw(ArgumentError("data of type $(typeof(data)) is not Tables.jl-compatible"))
+    Tables.columnaccess(data) && Tables.columns(data) === data ||
+        throw(ArgumentError("data of type $(typeof(data)) is not a column table"))
+    nrow = Tables.rowcount(data)
     if subset !== nothing
-        length(subset) != size(data, 1) &&
-            throw(DimensionMismatch("`data` of $(size(data, 1)) rows
-                cannot be matched with subset vector of $(length(subset)) elements"))
+        length(subset) == nrow || throw(DimensionMismatch(
+            "data contain $(nrow) rows while subset has $(length(subset)) elements"))
         esample = .!ismissing.(subset) .& subset
     else
-        esample = trues(size(data, 1))
+        esample = trues(nrow)
     end
 
     if weightname !== nothing
         colweights = getcolumn(data, weightname)
         esample .&= .!ismissing.(colweights) .& (colweights .> 0)
     end
-    
     sum(esample) == 0 && error("no nonmissing data")
     return (esample=esample,)
 end
@@ -62,6 +61,26 @@ const GroupTerms = StatsStep{:GroupTerms, typeof(groupterms), false}
 
 required(::GroupTerms) = (:treatintterms, :xterms)
 
+function checktreatvars(tr::DynamicTreatment{SharpDesign}, pr::TrendParallel{Unconditional},
+        treatvars::Vector{Symbol}, data)
+    # treatvars should be cohort and time variables
+    T1 = nonmissingtype(eltype(getcolumn(data, treatvars[1])))
+    T2 = nonmissingtype(eltype(getcolumn(data, treatvars[2])))
+    T1 == T2 || throw(ArgumentError(
+        "nonmissing elements from columns $(treatvars[1]) and $(treatvars[2]) have different types $T1 and $T2"))
+    T1 <: ValidTimeType ||
+        throw(ArgumentError("data column $(treatvars[1]) has unaccepted element type $(T1)"))
+    if T1 <: Union{TimeType, RotatingTimeValue{<:Any, <:TimeType}}
+        eltype(tr.exc) <: Period || throw(ArgumentError(
+            "element type $(eltype(tr.exc)) of excluded periods from $tr does not match element type $T1 from data; expect a subtype of Period"))
+        eltype(pr.e) == T1 || throw(ArgumentError("element type $(eltype(pr.e)) of control cohorts from $pr does not match element type $T1 from data; expect $T1"))
+    else
+        eltype(tr.exc) <: Integer || throw(ArgumentError(
+            "element type $(eltype(tr.exc)) of excluded periods from $tr does not match element type $T1 from data; expect integers"))
+        eltype(pr.e) == T1 || throw(ArgumentError("element type $(eltype(pr.e)) of control cohorts from $pr does not match element type $T1 from data; expect $T1"))
+    end
+end
+
 function _overlaptime(tr::DynamicTreatment, tr_rows::BitVector, data)
     control_time = Set(view(getcolumn(data, tr.time), .!tr_rows))
     treated_time = Set(view(getcolumn(data, tr.time), tr_rows))
@@ -75,18 +94,22 @@ function overlap!(esample::BitVector, tr_rows::BitVector, tr::DynamicTreatment,
         (esample .&= getcolumn(data, tr.time).∈(overlap_time,))
     tr_rows .&= esample
 end
-    
+
 function overlap!(esample::BitVector, tr_rows::BitVector, tr::DynamicTreatment,
         pr::NotYetTreatedParallel{Unconditional}, treatname::Symbol, data)
     overlap_time, _c, _t = _overlaptime(tr, tr_rows, data)
     timetype = eltype(overlap_time)
-    if timetype <: Integer
-        ecut = pr.ecut === nothing ? minimum(pr.e) : pr.ecut[1]
+    if !(timetype isa RotatingTimeValue)
+        ecut = pr.ecut[1]
         valid_cohort = filter(x -> x < ecut || x in pr.e, overlap_time)
         filter!(x -> x < ecut, overlap_time)
-        esample .&= (getcolumn(data, tr.time).∈(overlap_time,)) .&
-            (getcolumn(data, treatname).∈(valid_cohort,))
+    else
+        ecut = IdDict(e.rotation=>e.time for e in pr.ecut)
+        valid_cohort = filter(x -> x < ecut[x.rotation] || x in pr.e, overlap_time)
+        filter!(x -> x < ecut[x.rotation], overlap_time)
     end
+    esample .&= (getcolumn(data, tr.time).∈(overlap_time,)) .&
+            (getcolumn(data, treatname).∈(valid_cohort,))
     tr_rows .&= esample
 end
 
@@ -100,23 +123,21 @@ See also [`CheckVars`](@ref).
 function checkvars!(data, tr::AbstractTreatment, pr::AbstractParallel,
         yterm::AbstractTerm, treatname::Symbol, esample::BitVector,
         treatintterms::TermSet, xterms::TermSet)
+    # Do not check eltype of treatintterms
+    treatvars = union([treatname], termvars(tr), termvars(pr))
+    checktreatvars(tr, pr, treatvars, data)
 
-    treatvars = union([treatname], (termvars(t) for t in (tr, pr, treatintterms))...)
-    for v in treatvars
-        eltype(getcolumn(data, v)) <: Union{Missing, Integer} ||
-            throw(ArgumentError("data column $v has unaccepted element type"))
-    end
-
-    allvars = union(treatvars, (termvars(t) for t in (yterm, xterms))...)
-    untreatedvars = setdiff(allvars, termvars(treatintterms))
-    for v in untreatedvars
+    allvars = union(treatvars, termvars(yterm), termvars(xterms))
+    for v in allvars
         esample .&= .!ismissing.(getcolumn(data, v))
     end
     # Values of treatintterms from untreated units are ignored
-    tr_rows = istreated.(Ref(pr), getcolumn(data, treatname)) .& esample
-    for v in termvars(treatintterms)
+    tr_rows = esample .& istreated.(Ref(pr), getcolumn(data, treatname))
+    treatintvars = termvars(treatintterms)
+    for v in treatintvars
         esample[tr_rows] .&= .!ismissing.(view(getcolumn(data, v), tr_rows))
     end
+    isempty(treatintvars) || (tr_rows .&= esample)
 
     overlap!(esample, tr_rows, tr, pr, treatname, data)
     sum(esample) == 0 && error("no nonmissing data")

--- a/src/treatments.jl
+++ b/src/treatments.jl
@@ -41,13 +41,15 @@ See also [`dynamic`](@ref).
 
 # Fields
 - `time::Symbol`: column name of data representing calendar time.
-- `exc::Tuple{Vararg{Int}}`: excluded relative time.
+- `exc::Tuple{Vararg{ValidPeriodType}}`: excluded relative time.
 - `s::S`: an instance of [`TreatmentSharpness`](@ref).
 """
 struct DynamicTreatment{S<:TreatmentSharpness} <: AbstractTreatment
     time::Symbol
-    exc::Tuple{Vararg{Int}}
+    exc::Tuple{Vararg{ValidPeriodType}}
     s::S
+    DynamicTreatment(time::Symbol, exc::Period, s::TreatmentSharpness) =
+        new{typeof(s)}(time, (exc,), s)
     function DynamicTreatment(time::Symbol, exc, s::TreatmentSharpness)
         exc = exc !== nothing ? (unique!(sort!([exc...]))...,) : ()
         return new{typeof(s)}(time, exc, s)

--- a/src/treatments.jl
+++ b/src/treatments.jl
@@ -41,12 +41,12 @@ See also [`dynamic`](@ref).
 
 # Fields
 - `time::Symbol`: column name of data representing calendar time.
-- `exc::Tuple{Vararg{Signed}}`: excluded relative time.
+- `exc::Tuple{Vararg{Integer}}`: excluded relative time.
 - `s::S`: an instance of [`TreatmentSharpness`](@ref).
 """
 struct DynamicTreatment{S<:TreatmentSharpness} <: AbstractTreatment
     time::Symbol
-    exc::Tuple{Vararg{Signed}}
+    exc::Tuple{Vararg{Integer}}
     s::S
     function DynamicTreatment(time::Symbol, exc, s::TreatmentSharpness)
         exc = exc !== nothing ? (unique!(sort!([exc...]))...,) : ()

--- a/src/treatments.jl
+++ b/src/treatments.jl
@@ -41,15 +41,13 @@ See also [`dynamic`](@ref).
 
 # Fields
 - `time::Symbol`: column name of data representing calendar time.
-- `exc::Tuple{Vararg{ValidPeriodType}}`: excluded relative time.
+- `exc::Tuple{Vararg{Signed}}`: excluded relative time.
 - `s::S`: an instance of [`TreatmentSharpness`](@ref).
 """
 struct DynamicTreatment{S<:TreatmentSharpness} <: AbstractTreatment
     time::Symbol
-    exc::Tuple{Vararg{ValidPeriodType}}
+    exc::Tuple{Vararg{Signed}}
     s::S
-    DynamicTreatment(time::Symbol, exc::Period, s::TreatmentSharpness) =
-        new{typeof(s)}(time, (exc,), s)
     function DynamicTreatment(time::Symbol, exc, s::TreatmentSharpness)
         exc = exc !== nothing ? (unique!(sort!([exc...]))...,) : ()
         return new{typeof(s)}(time, exc, s)

--- a/src/treatments.jl
+++ b/src/treatments.jl
@@ -41,12 +41,12 @@ See also [`dynamic`](@ref).
 
 # Fields
 - `time::Symbol`: column name of data representing calendar time.
-- `exc::Tuple{Vararg{Integer}}`: excluded relative time.
+- `exc::Tuple{Vararg{Int}}`: excluded relative time.
 - `s::S`: an instance of [`TreatmentSharpness`](@ref).
 """
 struct DynamicTreatment{S<:TreatmentSharpness} <: AbstractTreatment
     time::Symbol
-    exc::Tuple{Vararg{Integer}}
+    exc::Tuple{Vararg{Int}}
     s::S
     function DynamicTreatment(time::Symbol, exc, s::TreatmentSharpness)
         exc = exc !== nothing ? (unique!(sort!([exc...]))...,) : ()

--- a/test/ScaledArrays.jl
+++ b/test/ScaledArrays.jl
@@ -26,7 +26,9 @@ using DiffinDiffsBase: RefArray, validstartstepstop, _scaledlabel
     ss = validstartstepstop(s, 1, 2, 9, true)
     @test ss == (1.0, 9.0)
     @test typeof(ss) == Tuple{Float64, Float64}
-
+    @test_throws ArgumentError validstartstepstop(1:5, 1, nothing, 1, true)
+    @test_throws ArgumentError validstartstepstop(1:5, 1, Year(1), 1, true)
+    @test_throws ArgumentError validstartstepstop(1:5, 1, 0, 1, true)
 
     sa1 = ScaledArray(p, 2, usepool=false)
     @test sa1.refs == [1, repeat(1:4, inner=2)..., 4]
@@ -35,14 +37,14 @@ using DiffinDiffsBase: RefArray, validstartstepstop, _scaledlabel
     @test sa1.stop == 9
     @test sa1 != sa
 
-    sa2 = ScaledArray(sa1, 1, start=1, stop=10)
-    @test sa2.refs == [2, repeat(2:2:8, inner=2)..., 8]
-    @test sa2.start == 1
+    sa2 = ScaledArray(sa1, 2, 1, 10)
+    @test sa2.refs == [1, repeat(1:2:7, inner=2)..., 7]
+    @test sa2.start == 2
     @test sa2.step == 1
     @test sa2.stop == 10
     @test sa2 == sa1
 
-    sa3 = ScaledArray(sa2, ref_type=Int16, start=0, stop=8, usepool=false)
+    sa3 = ScaledArray(sa2, reftype=Int16, start=0, stop=8, usepool=false)
     @test sa3.refs == [3, repeat(3:2:9, inner=2)..., 9]
     @test eltype(sa3.refs) == Int16
     @test sa3.start == 0
@@ -56,7 +58,11 @@ using DiffinDiffsBase: RefArray, validstartstepstop, _scaledlabel
     @test sa4.stop == 8
     @test sa4 == sa3
 
-    @test_throws ArgumentError ScaledArray(sa4, stop=7, usepool=false)
+    sa5 = ScaledArray(sa4, usepool=false)
+    @test sa5.refs == sa4.refs
+    @test sa5.refs !== sa4.refs
+
+    @test_throws ArgumentError ScaledArray(sa5, stop=7, usepool=false)
 
     @test size(sa) == (10,)
     @test IndexStyle(typeof(sa)) == IndexLinear()
@@ -112,4 +118,8 @@ end
     @test eltype(refs) == Int16
     @test typeof(start) == Float64
     @test typeof(step) == Int
+
+    refs, start, step, stop = _scaledlabel(1:typemax(Int16), 1, Int8)
+    @test refs == 1:typemax(Int16)
+    @test eltype(refs) == Int16
 end

--- a/test/ScaledArrays.jl
+++ b/test/ScaledArrays.jl
@@ -1,0 +1,115 @@
+using DiffinDiffsBase: RefArray, validstartstepstop, _scaledlabel
+
+@testset "ScaledArray" begin
+    refs = repeat(1:5, outer=2)
+    pool = Date(1):Year(1):Date(5)
+    sa = ScaledArray(RefArray(refs), Date(1), Year(1), Date(5))
+    @test sa == ScaledArray(RefArray(refs), Date(1), Year(1), Date(5), pool)
+    @test sa.refs == refs
+    @test sa.start == Date(1)
+    @test sa.step == Year(1)
+    @test sa.stop == Date(5)
+    @test sa.pool == pool
+    @test sa == sa
+
+    x = 1:10
+    @test validstartstepstop(x, 10, -1, nothing, true) == (10, 1)
+    @test_throws ArgumentError validstartstepstop(x, 1, -1, 10, true)
+    p = PooledArray(x)
+    p[1] = 2
+    p[10] = 9
+    @test validstartstepstop(p, nothing, 1, nothing, true) == (1, 10)
+    @test_throws ArgumentError validstartstepstop(p, 2, 1, 9, true)
+    @test validstartstepstop(p, 2, 1, nothing, false) == (2, 9)
+    @test_throws ArgumentError validstartstepstop(p, 2, 1, 8, false)
+    s = ScaledArray(1.0:2.0:9.0, 1.0, 2, 10)
+    ss = validstartstepstop(s, 1, 2, 9, true)
+    @test ss == (1.0, 9.0)
+    @test typeof(ss) == Tuple{Float64, Float64}
+
+
+    sa1 = ScaledArray(p, 2, usepool=false)
+    @test sa1.refs == [1, repeat(1:4, inner=2)..., 4]
+    @test sa1.start == 2
+    @test sa1.step == 2
+    @test sa1.stop == 9
+    @test sa1 != sa
+
+    sa2 = ScaledArray(sa1, 1, start=1, stop=10)
+    @test sa2.refs == [2, repeat(2:2:8, inner=2)..., 8]
+    @test sa2.start == 1
+    @test sa2.step == 1
+    @test sa2.stop == 10
+    @test sa2 == sa1
+
+    sa3 = ScaledArray(sa2, ref_type=Int16, start=0, stop=8, usepool=false)
+    @test sa3.refs == [3, repeat(3:2:9, inner=2)..., 9]
+    @test eltype(sa3.refs) == Int16
+    @test sa3.start == 0
+    @test sa3.step == 1
+    @test sa3.stop == 8
+    @test sa3 == sa2
+
+    sa4 = ScaledArray(sa3, start=2, stop=8, usepool=false)
+    @test sa4.refs == [1, repeat(1:2:7, inner=2)..., 7]
+    @test sa4.start == 2
+    @test sa4.stop == 8
+    @test sa4 == sa3
+
+    @test_throws ArgumentError ScaledArray(sa4, stop=7, usepool=false)
+
+    @test size(sa) == (10,)
+    @test IndexStyle(typeof(sa)) == IndexLinear()
+
+    @test refarray(sa) === sa.refs
+    @test refvalue(sa, 1) == Date(1)
+    @test refpool(sa) === sa.pool
+
+    ssa = view(sa, 3:4)
+    @test refarray(ssa) == view(sa.refs, 3:4)
+    @test refvalue(ssa, 1) == Date(1)
+    @test refpool(ssa) === sa.pool
+
+    @test sa[1] == Date(1)
+    @test sa[1:2] == sa[[1,2]] == sa[(1:10).<3] == Date.(1:2)
+end
+
+@testset "_scaledlabel" begin
+    x = Date.(10:-2:0)
+    refs, start, step, stop = _scaledlabel(x, Year(1), start=Date(-1), stop=Date(11))
+    @test refs == 12:-2:2
+    @test eltype(refs) == Int32
+    @test start == Date(-1)
+    @test step == Year(1)
+    @test stop == Date(11)
+
+    refs, start, step, stop = _scaledlabel(x, Year(2), Int16)
+    @test refs == 6:-1:1
+    @test eltype(refs) == Int16
+    @test start == Date(0)
+    @test step == Year(2)
+    @test stop == Date(10)
+
+    x = ScaledArray(RefArray(refs), start, step, stop)
+    refs1, start1, step1, stop1 = _scaledlabel(x, Year(2))
+    @test refs1 == refs && refs1 !== refs
+    @test eltype(refs1) == Int32
+    @test start1 == start
+    @test step1 == step
+    @test stop1 == stop
+
+    refs1, start1, step1, stop1 = _scaledlabel(x, Year(2), Int16)
+    @test refs1 == 6:-1:1
+    @test eltype(refs1) == Int16
+
+    refs1, start1, step1, stop1 = _scaledlabel(x, Year(1), start=Date(-1), stop=Date(11))
+    @test refs1 == 12:-2:2
+    @test start1 == Date(-1)
+    @test step1 == Year(1)
+
+    refs, start, step, stop = _scaledlabel(1.0:200.0, 1, Int8)
+    @test refs == 1:200
+    @test eltype(refs) == Int16
+    @test typeof(start) == Float64
+    @test typeof(step) == Int
+end

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -49,7 +49,7 @@ end
 
     panel1 = setpanel(hrs, :hhidpn, :wave, 0.5, ref_type=Int)
     @test view(diff(panel1.refs), inidbounds) == 2 .* view(diff(hrs.wave), inidbounds)
-    @test panel1.timepool == 7:11
+    @test panel1.timepool == 7.0:0.5:11.0
     @test eltype(panel1.refs) == Int
 
     @test_throws ArgumentError setpanel(hrs, :hhidpn, :oop_spend)
@@ -60,14 +60,14 @@ end
     @test sprint(show, MIME("text/plain"), panel) == """
         Panel Structure:
           idpool:   [1, 2, 3, 4, 5, 6, 7, 8, 9, 10  …  647, 648, 649, 650, 651, 652, 653, 654, 655, 656]
-          timepool:   [7, 8, 9, 10, 11]
+          timepool:   7:1:11
           laginds:  Dict{Int64,$t}()"""
 
     lags = findlag!(panel)
     @test sprint(show, MIME("text/plain"), panel) == """
         Panel Structure:
           idpool:   [1, 2, 3, 4, 5, 6, 7, 8, 9, 10  …  647, 648, 649, 650, 651, 652, 653, 654, 655, 656]
-          timepool:   [7, 8, 9, 10, 11]
+          timepool:   7:1:11
           laginds:  Dict(1 => [4, 5, 1, 2, 0, 7, 0, 10, 8, 6  …  0, 3275, 3271, 3273, 3274, 3279, 3280, 3277, 3278, 0])"""
 
     leads = findlead!(panel, -1)

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -37,6 +37,17 @@ end
     @test rows[1] == intersect(findall(x->x==7, hrs.wave), findall(x->x==8, hrs.wave_hosp))
 end
 
+@testset "settime" begin
+    hrs = exampledata("hrs")
+    t = settime(hrs, :wave, step=2, reftype=Int16)
+    @test eltype(refarray(t)) == Int16
+    @test sort!(unique(refarray(t))) == 1:3
+    t = settime(hrs, :wave, rotation=isodd.(hrs.wave))
+    @test eltype(t) == eltype(hrs.wave)
+    @test eltype(refarray(t)) == RotatingTimeValue{Bool, Int32}
+    @test all(x->x.rotation==isodd(x.time), t.refs)
+end
+
 @testset "PanelStructure" begin
     hrs = exampledata("hrs")
     N = size(hrs, 1)
@@ -47,7 +58,7 @@ end
     @test length(panel.idpool) == 656
     @test panel.timepool == 7:11
 
-    panel1 = setpanel(hrs, :hhidpn, :wave, 0.5, ref_type=Int)
+    panel1 = setpanel(hrs, :hhidpn, :wave, step=0.5, reftype=Int)
     @test view(diff(panel1.refs), inidbounds) == 2 .* view(diff(hrs.wave), inidbounds)
     @test panel1.timepool == 7.0:0.5:11.0
     @test eltype(panel1.refs) == Int

--- a/test/procedures.jl
+++ b/test/procedures.jl
@@ -91,7 +91,7 @@ end
         rot = ifelse.(isodd.(df.hhidpn), 1, 2)
         df.wave_hosp = rotatingtime(rot, df.wave_hosp)
         df.wave = rotatingtime(rot, df.wave)
-        e = rotatingtime.((1,2), 11)
+        e = rotatingtime((1,2), 11)
         nt = merge(nt, (data=df, tr=dynamic(:wave, -1), pr=nevertreated(e), treatintterms=TermSet(), xterms=TermSet(), esample=trues(size(hrs,1))))
         @test checkvars!(nt...) == (esample=trues(size(df,1)),
             tr_rows=getfield.(df.wave_hosp, :time).!=11)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using DiffinDiffsBase
 
 using DataFrames
+using Dates: Date, Year
 using DiffinDiffsBase: @fieldequal, unpack, @unpack, hastreat, parse_treat,
     isintercept, isomitsintercept, parse_intercept!,
     ncol, nrow,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,10 @@
 using Test
 using DiffinDiffsBase
 
+using DataAPI: refarray, refvalue, refpool
 using DataFrames
 using Dates: Date, Year
-using DiffinDiffsBase: @fieldequal, unpack, @unpack, hastreat, parse_treat,
+using DiffinDiffsBase: @fieldequal, unpack, @unpack, checktable, hastreat, parse_treat,
     isintercept, isomitsintercept, parse_intercept!,
     ncol, nrow,
     _f, _byid, groupargs, copyargs, pool, checkdata, groupterms, checkvars!, makeweights,
@@ -23,6 +24,7 @@ include("testutils.jl")
 const tests = [
     "utils",
     "tables",
+    "ScaledArrays",
     "terms",
     "treatments",
     "parallels",

--- a/test/treatments.jl
+++ b/test/treatments.jl
@@ -12,14 +12,16 @@ end
 @testset "dynamic" begin
     dt0 = DynamicTreatment(:month, nothing, SharpDesign())
     dt1 = DynamicTreatment(:month, -1, SharpDesign())
+    dt1y = DynamicTreatment(:month, Year(-1), SharpDesign())
     dt2 = DynamicTreatment(:month, [-2,-1], SharpDesign())
+    dt2y = DynamicTreatment(:month, Year.([-2,-1]), SharpDesign())
     
     @testset "inner constructor" begin
         @test DynamicTreatment(:month, [], SharpDesign()) == dt0
         @test DynamicTreatment(:month, [-1], SharpDesign()) == dt1
         @test DynamicTreatment(:month, [-1,-1,-2], SharpDesign()) == dt2
-        @test DynamicTreatment(:month, [-1.0], SharpDesign()) == dt1
-        @test_throws InexactError DynamicTreatment(:month, [-1.5], SharpDesign())
+        @test_throws MethodError DynamicTreatment(:month, [-1.0], SharpDesign())
+        @test_throws MethodError DynamicTreatment(:month, [-1.5], SharpDesign())
     end
 
     @testset "without @formula" begin
@@ -29,6 +31,9 @@ end
         @test dynamic(:month, [-1], sharp()) == dt1
         @test dynamic(:month, -2:-1) == dt2
         @test dynamic(:month, Set([-1,-2]), sharp()) == dt2
+
+        @test dynamic(:month, Year(-1)) == dt1y
+        @test dynamic(:month, (Year(-1), Year(-2))) == dt2y
     end
 
     @testset "with @formula" begin
@@ -74,6 +79,12 @@ end
             Sharp dynamic treatment:
               column name of time variable: month
               excluded relative time: -2, -1"""
+
+        @test sprint(show, dt2y) == "Dynamic{S}(Year(-2), Year(-1))"
+        @test sprint(show, MIME("text/plain"), dt2y) == """
+            Sharp dynamic treatment:
+              column name of time variable: month
+              excluded relative time: -2 years, -1 year"""
     end
 end
 

--- a/test/treatments.jl
+++ b/test/treatments.jl
@@ -12,16 +12,14 @@ end
 @testset "dynamic" begin
     dt0 = DynamicTreatment(:month, nothing, SharpDesign())
     dt1 = DynamicTreatment(:month, -1, SharpDesign())
-    dt1y = DynamicTreatment(:month, Year(-1), SharpDesign())
     dt2 = DynamicTreatment(:month, [-2,-1], SharpDesign())
-    dt2y = DynamicTreatment(:month, Year.([-2,-1]), SharpDesign())
-    
+
     @testset "inner constructor" begin
         @test DynamicTreatment(:month, [], SharpDesign()) == dt0
         @test DynamicTreatment(:month, [-1], SharpDesign()) == dt1
         @test DynamicTreatment(:month, [-1,-1,-2], SharpDesign()) == dt2
-        @test_throws MethodError DynamicTreatment(:month, [-1.0], SharpDesign())
-        @test_throws MethodError DynamicTreatment(:month, [-1.5], SharpDesign())
+        @test DynamicTreatment(:month, [-1.0], SharpDesign()) == dt1
+        @test_throws InexactError DynamicTreatment(:month, [-1.5], SharpDesign())
     end
 
     @testset "without @formula" begin
@@ -31,9 +29,6 @@ end
         @test dynamic(:month, [-1], sharp()) == dt1
         @test dynamic(:month, -2:-1) == dt2
         @test dynamic(:month, Set([-1,-2]), sharp()) == dt2
-
-        @test dynamic(:month, Year(-1)) == dt1y
-        @test dynamic(:month, (Year(-1), Year(-2))) == dt2y
     end
 
     @testset "with @formula" begin
@@ -79,12 +74,6 @@ end
             Sharp dynamic treatment:
               column name of time variable: month
               excluded relative time: -2, -1"""
-
-        @test sprint(show, dt2y) == "Dynamic{S}(Year(-2), Year(-1))"
-        @test sprint(show, MIME("text/plain"), dt2y) == """
-            Sharp dynamic treatment:
-              column name of time variable: month
-              excluded relative time: -2 years, -1 year"""
     end
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -37,6 +37,14 @@ end
     @test getfield.(rt, :rotation) == rot
     @test getfield.(rt, :time) == time
 
+    rtd = rotatingtime(1, Date(1))
+    rt1 = rotatingtime(1, 1)
+    @test rtd + Year(1) == Year(1) + rtd == rotatingtime(1, Date(2))
+    @test rtd - Year(1) == rotatingtime(1, Date(0))
+    @test 1 - rt1 == rotatingtime(1, 0)
+    @test_throws MethodError Year(3) - rtd
+    @test 2 * rt1 == rt1 * 2 == rotatingtime(1, 2)
+
     @test rt[1] - rt[2] == -1
     @test_throws ArgumentError rt[1] - rt[6]
 
@@ -50,4 +58,9 @@ end
         RotatingTimeValue{Int64,$(w)Int64}:
           rotation: 5
           time:     1"""
+end
+
+@testset "checktable" begin
+    @test_throws ArgumentError checktable(rand(3,3))
+    @test_throws ArgumentError checktable([(a=1, b=2), (a=1, b=2)])
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -52,6 +52,14 @@ end
     @test isless(rt[6], rt[1])
     @test rt[1] == RotatingTimeValue(Int32(5), Int32(1))
 
+    @test checkindex(Bool, 1:5, rt1)
+    @test checkindex(Bool, 2:5, rt1) == false
+    X = 1:5
+    @test X[rt1] == 1
+    rts = rotatingtime(1, 2:3)
+    @test X[rts] == 2:3
+    @test_throws BoundsError (1:2)[rts]
+
     @test sprint(show, rt[1]) == "5_1"
     w = VERSION < v"1.6.0" ? "" : " "
     @test sprint(show, MIME("text/plain"), rt[1]) == """

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -27,3 +27,27 @@ end
     @test size(exampledata(:nsw)) == (32834,)
     @test size(exampledata(:mpdta)) == (2500,)
 end
+
+@testset "RotatingTimeValue" begin
+    @test rotatingtime(1.0, Date(1)) == RotatingTimeValue(1.0, Date(1))
+    rot = repeat(5:-1:1, inner=5)
+    time = repeat(1:5, outer=5)
+    rt = rotatingtime(rot, time)
+    @test eltype(rt) == RotatingTimeValue{Int, Int}
+    @test getfield.(rt, :rotation) == rot
+    @test getfield.(rt, :time) == time
+
+    @test rt[1] - rt[2] == -1
+    @test_throws ArgumentError rt[1] - rt[6]
+
+    @test isless(rt[1], rt[2])
+    @test isless(rt[6], rt[1])
+    @test rt[1] == RotatingTimeValue(Int32(5), Int32(1))
+
+    @test sprint(show, rt[1]) == "5_1"
+    w = VERSION < v"1.6.0" ? "" : " "
+    @test sprint(show, MIME("text/plain"), rt[1]) == """
+        RotatingTimeValue{Int64,$(w)Int64}:
+          rotation: 5
+          time:     1"""
+end


### PR DESCRIPTION
1. The new array type `ScaledArray` is helpful for working with time data that are not integers. Otherwise, it may not be clear which value represents the next time period.
2. To allow working with rotating panels where the time periods may overlap across different rotation groups, `RotatingTimeValue` replaces the default integer reference values in `ScaledArray`. It can also be used as array index and supports some basic arithmetics.
3. The new function `settime` is only necessary when the time data are not integers.
