### PR TITLE
Improve ScaledArray and add RotatingTimeRange

### DIFF
--- a/src/DiffinDiffsBase.jl
+++ b/src/DiffinDiffsBase.jl
@@ -32,8 +32,10 @@ export coef, vcov, stderror, confint, nobs, dof_residual, responsename, coefname
 export cb,
        ≊,
        exampledata,
+
        RotatingTimeValue,
        rotatingtime,
+       RotatingRange,
 
        VecColumnTable,
        VecColsRow,
@@ -46,6 +48,7 @@ export cb,
        ScaledArray,
        ScaledVector,
        ScaledMatrix,
+       scale,
 
        TreatmentSharpness,
        SharpDesign,
@@ -126,6 +129,7 @@ export cb,
        rescale
 
 include("utils.jl")
+include("time.jl")
 include("tables.jl")
 include("ScaledArrays.jl")
 include("treatments.jl")

--- a/src/procedures.jl
+++ b/src/procedures.jl
@@ -93,12 +93,16 @@ function overlap!(esample::BitVector, tr_rows::BitVector, tr::DynamicTreatment,
         pr::NotYetTreatedParallel{Unconditional}, treatname::Symbol, data)
     overlap_time, _c, _t = _overlaptime(tr, tr_rows, data)
     timetype = eltype(overlap_time)
+    invpool = invrefpool(getcolumn(data, tr.time))
     if !(timetype <: RotatingTimeValue)
         ecut = pr.ecut[1]
+        invpool === nothing || (ecut = invpool[ecut])
         valid_cohort = filter(x -> x < ecut || x in pr.e, overlap_time)
         filter!(x -> x < ecut, overlap_time)
     else
-        ecut = IdDict(e.rotation=>e.time for e in pr.ecut)
+        ecut = pr.ecut
+        invpool === nothing || (ecut = (invpool[e] for e in ecut))
+        ecut = IdDict(e.rotation=>e.time for e in ecut)
         valid_cohort = filter(x -> x.time < ecut[x.rotation] || x in pr.e, overlap_time)
         filter!(x -> x.time < ecut[x.rotation], overlap_time)
     end

--- a/src/time.jl
+++ b/src/time.jl
@@ -68,7 +68,6 @@ Base.iterate(x::RotatingTimeValue, ::Any) = nothing
 
 Base.length(x::RotatingTimeValue) = 1
 
-
 show(io::IO, x::RotatingTimeValue) = print(io, x.rotation, "_", x.time)
 function show(io::IO, ::MIME"text/plain", x::RotatingTimeValue)
     println(io, typeof(x), ':')

--- a/src/time.jl
+++ b/src/time.jl
@@ -1,0 +1,106 @@
+"""
+    RotatingTimeValue{R, T}
+
+A wrapper around a time value for distinguishing potentially different
+rotation group it could belong to in a rotating sampling design.
+See also [`rotatingtime`](@ref) and [`settime`](@ref).
+
+# Fields
+- `rotation::R`: a rotation group in a rotating sampling design.
+- `time::T`: a time value belonged to the rotation group.
+"""
+struct RotatingTimeValue{R, T}
+    rotation::R
+    time::T
+end
+
+RotatingTimeValue(::Type{RotatingTimeValue{R,T}}, rotation, time) where {R,T} =
+    RotatingTimeValue(convert(R, rotation), convert(T, time))
+
+"""
+    rotatingtime(rotation, time)
+
+Construct [`RotatingTimeValue`](@ref)s from `rotation` and `time`.
+This method simply broadcasts the default constructor over the arguments.
+"""
+rotatingtime(rotation, time) = RotatingTimeValue.(rotation, time)
+
++(x::RotatingTimeValue, y) = RotatingTimeValue(x.rotation, x.time + y)
++(x, y::RotatingTimeValue) = RotatingTimeValue(y.rotation, x + y.time)
+-(x::RotatingTimeValue, y) = RotatingTimeValue(x.rotation, x.time - y)
+-(x, y::RotatingTimeValue) = RotatingTimeValue(y.rotation, x - y.time)
+*(x::RotatingTimeValue, y) = RotatingTimeValue(x.rotation, x.time * y)
+*(x, y::RotatingTimeValue) = RotatingTimeValue(y.rotation, x * y.time)
+
+function -(x::RotatingTimeValue, y::RotatingTimeValue)
+    rx = x.rotation
+    ry = y.rotation
+    rx == ry || throw(ArgumentError("x has rotation $rx while y has rotation $ry"))
+    return x.time - y.time
+end
+
+# Compare time first
+isless(x::RotatingTimeValue, y::RotatingTimeValue) =
+    isequal(x.time, y.time) ? isless(x.rotation, y.rotation) : isless(x.time, y.time)
+
+isless(x::RotatingTimeValue, y) = isless(x.time, y)
+isless(x, y::RotatingTimeValue) = isless(x, y.time)
+
+==(x::RotatingTimeValue, y::RotatingTimeValue) =
+    x.rotation == y.rotation && x.time == y.time
+
+==(x::RotatingTimeValue, y) = x.time == y
+==(x, y::RotatingTimeValue) = x == y.time
+
+Base.zero(::Type{RotatingTimeValue{R,T}}) where {R,T} = RotatingTimeValue(zero(R), zero(T))
+Base.iszero(x::RotatingTimeValue) = iszero(x.time)
+
+Base.convert(::Type{RotatingTimeValue{R,T}}, x::RotatingTimeValue) where {R,T} =
+    RotatingTimeValue(convert(R, x.rotation), convert(T, x.time))
+
+Base.checkindex(::Type{Bool}, inds::AbstractUnitRange, i::RotatingTimeValue) =
+    checkindex(Bool, inds, i.time)
+
+@propagate_inbounds getindex(X::AbstractArray, i::RotatingTimeValue) = getindex(X, i.time)
+
+Base.iterate(x::RotatingTimeValue) = (x, nothing)
+Base.iterate(x::RotatingTimeValue, ::Any) = nothing
+
+Base.length(x::RotatingTimeValue) = 1
+
+
+show(io::IO, x::RotatingTimeValue) = print(io, x.rotation, "_", x.time)
+function show(io::IO, ::MIME"text/plain", x::RotatingTimeValue)
+    println(io, typeof(x), ':')
+    println(io, "  rotation: ", x.rotation)
+    print(io, "  time:     ", x.time)
+end
+
+"""
+    RotatingTimeRange{T<:RotatingTimeValue,R<:AbstractRange} <: AbstractRange{T}
+
+A range type that wraps a [`RotationTimeValue`](@ref) with a range of type `R`
+for producing a range of [`RotationTimeValue`](@ref)s.
+It can be created with the syntax `a:b:c` when `a` and `c` are [`RotationTimeValue`](@ref)s.
+"""
+struct RotatingTimeRange{T<:RotatingTimeValue,R<:AbstractRange} <: AbstractRange{T}
+    value::T
+    range::R
+end
+
+Base.:(:)(start::RotatingTimeValue, step, stop::RotatingTimeValue) =
+    RotatingTimeRange(start, start.time:step:stop.time)
+
+Base.first(r::RotatingTimeRange) = RotatingTimeValue(r.value.rotation, first(r.range))
+Base.step(r::RotatingTimeRange) = step(r.range)
+Base.last(r::RotatingTimeRange) = RotatingTimeValue(r.value.rotation, last(r.range))
+
+Base.length(r::RotatingTimeRange) = length(r.range)
+
+@propagate_inbounds Base.getindex(r::RotatingTimeRange{T}, i::Int) where T =
+    RotatingTimeValue(T, r.value.rotation, r.range[i])
+
+@propagate_inbounds Base.getindex(r::RotatingTimeRange{T}, i::RotatingTimeValue) where T =
+    RotatingTimeValue(T, i.rotation, r.range[i.time])
+
+const ValidTimeType = Union{Signed, TimeType, Period, RotatingTimeValue}

--- a/test/ScaledArrays.jl
+++ b/test/ScaledArrays.jl
@@ -1,61 +1,49 @@
-using DiffinDiffsBase: RefArray, validstartstepstop, _scaledlabel
+using DiffinDiffsBase: RefArray, validpool, scaledlabel
 
 @testset "ScaledArray" begin
     refs = repeat(1:5, outer=2)
     pool = Date(1):Year(1):Date(5)
-    sa = ScaledArray(RefArray(refs), Date(1), Year(1), Date(5))
-    @test sa == ScaledArray(RefArray(refs), Date(1), Year(1), Date(5), pool)
-    @test sa.refs == refs
-    @test sa.start == Date(1)
-    @test sa.step == Year(1)
-    @test sa.stop == Date(5)
-    @test sa.pool == pool
-    @test sa == sa
+    invpool = Dict(p=>i for (i, p) in enumerate(pool))
+    sa = ScaledArray(RefArray(refs), pool, invpool)
+    @test sa.refs === refs
 
     x = 1:10
-    @test validstartstepstop(x, 10, -1, nothing, true) == (10, 1)
-    @test_throws ArgumentError validstartstepstop(x, 1, -1, 10, true)
+    @test validpool(x, Int, 10, -1, nothing, true) == 10:-1:1
+    @test_throws ArgumentError validpool(x, Int, 1, -1, 10, true)
     p = PooledArray(x)
     p[1] = 2
     p[10] = 9
-    @test validstartstepstop(p, nothing, 1, nothing, true) == (1, 10)
-    @test_throws ArgumentError validstartstepstop(p, 2, 1, 9, true)
-    @test validstartstepstop(p, 2, 1, nothing, false) == (2, 9)
-    @test_throws ArgumentError validstartstepstop(p, 2, 1, 8, false)
+    @test validpool(p, Int, nothing, 1, nothing, true) == 1:10
+    @test_throws ArgumentError validpool(p, Int, 2, 1, 9, true)
+    @test validpool(p, Int, 2, 1, nothing, false) == 2:9
+    @test_throws ArgumentError validpool(p, Int, 2, 1, 8, false)
     s = ScaledArray(1.0:2.0:9.0, 1.0, 2, 10)
-    ss = validstartstepstop(s, 1, 2, 9, true)
-    @test ss == (1.0, 9.0)
-    @test typeof(ss) == Tuple{Float64, Float64}
-    @test_throws ArgumentError validstartstepstop(1:5, 1, nothing, 1, true)
-    @test_throws ArgumentError validstartstepstop(1:5, 1, Year(1), 1, true)
-    @test_throws ArgumentError validstartstepstop(1:5, 1, 0, 1, true)
+    ss = validpool(s, Float64, 1, 2, 9, true)
+    @test ss == 1.0:2.0:9.0
+    @test eltype(ss) == Float64
+    @test_throws ArgumentError validpool(1:5, Int, 1, nothing, 1, true)
+    @test_throws ArgumentError validpool(1:5, Int, 1, Year(1), 1, true)
+    @test_throws ArgumentError validpool(1:5, Int, 1, 0, 1, true)
 
     sa1 = ScaledArray(p, 2, usepool=false)
     @test sa1.refs == [1, repeat(1:4, inner=2)..., 4]
-    @test sa1.start == 2
-    @test sa1.step == 2
-    @test sa1.stop == 9
+    @test sa1.pool == 2:2:9
     @test sa1 != sa
 
     sa2 = ScaledArray(sa1, 2, 1, 10)
     @test sa2.refs == [1, repeat(1:2:7, inner=2)..., 7]
-    @test sa2.start == 2
-    @test sa2.step == 1
-    @test sa2.stop == 10
+    @test sa2.pool == 2:10
     @test sa2 == sa1
 
     sa3 = ScaledArray(sa2, reftype=Int16, start=0, stop=8, usepool=false)
     @test sa3.refs == [3, repeat(3:2:9, inner=2)..., 9]
     @test eltype(sa3.refs) == Int16
-    @test sa3.start == 0
-    @test sa3.step == 1
-    @test sa3.stop == 8
+    @test sa3.pool == 0:8
     @test sa3 == sa2
 
     sa4 = ScaledArray(sa3, start=2, stop=8, usepool=false)
     @test sa4.refs == [1, repeat(1:2:7, inner=2)..., 7]
-    @test sa4.start == 2
-    @test sa4.stop == 8
+    @test sa4.pool == 2:8
     @test sa4 == sa3
 
     sa5 = ScaledArray(sa4, usepool=false)
@@ -80,46 +68,54 @@ using DiffinDiffsBase: RefArray, validstartstepstop, _scaledlabel
     @test sa[1:2] == sa[[1,2]] == sa[(1:10).<3] == Date.(1:2)
 end
 
-@testset "_scaledlabel" begin
+@testset "scaledlabel" begin
     x = Date.(10:-2:0)
-    refs, start, step, stop = _scaledlabel(x, Year(1), start=Date(-1), stop=Date(11))
+    pl = Date(-1):Year(1):Date(11)
+    refs, pool, invpool = scaledlabel(x, Year(1), start=Date(-1), stop=Date(11))
     @test refs == 12:-2:2
     @test eltype(refs) == Int32
-    @test start == Date(-1)
-    @test step == Year(1)
-    @test stop == Date(11)
+    @test pool == pl
 
-    refs, start, step, stop = _scaledlabel(x, Year(2), Int16)
+    pl = Date(0):Year(2):Date(10)
+    ip = Dict(p=>i for (i, p) in enumerate(pl))
+    refs, pool, invpool = scaledlabel(x, Year(2), Int16)
     @test refs == 6:-1:1
     @test eltype(refs) == Int16
-    @test start == Date(0)
-    @test step == Year(2)
-    @test stop == Date(10)
+    @test pool == pl
+    @test invpool == ip
+    @test valtype(invpool) == Int16
 
-    x = ScaledArray(RefArray(refs), start, step, stop)
-    refs1, start1, step1, stop1 = _scaledlabel(x, Year(2))
-    @test refs1 == refs && refs1 !== refs
+    x = ScaledArray(RefArray(refs), Date(0):Year(2):Date(10), invpool)
+    refs1, pool1, invpool1 = scaledlabel(x, Year(2))
+    @test refs1 == x.refs && refs1 !== x.refs
     @test eltype(refs1) == Int32
-    @test start1 == start
-    @test step1 == step
-    @test stop1 == stop
+    @test pool1 == x.pool
+    @test invpool1 == x.invpool && invpool1 !== x.invpool
 
-    refs1, start1, step1, stop1 = _scaledlabel(x, Year(2), Int16)
+    refs1, pool1, invpool1 = scaledlabel(x, Year(2), Int16)
     @test refs1 == 6:-1:1
     @test eltype(refs1) == Int16
+    @test pool1 == pl
+    @test invpool1 == ip
+    @test valtype(invpool1) == Int16
 
-    refs1, start1, step1, stop1 = _scaledlabel(x, Year(1), start=Date(-1), stop=Date(11))
+    refs1, pool1, invpool1 = scaledlabel(x, Year(1), start=Date(-1), stop=Date(11))
     @test refs1 == 12:-2:2
-    @test start1 == Date(-1)
-    @test step1 == Year(1)
+    @test pool1 == Date(-1):Year(1):Date(11)
 
-    refs, start, step, stop = _scaledlabel(1.0:200.0, 1, Int8)
+    refs, pool, invpool = scaledlabel(1.0:200.0, 1, Int8, Int)
     @test refs == 1:200
     @test eltype(refs) == Int16
-    @test typeof(start) == Float64
-    @test typeof(step) == Int
+    @test pool == 1:200
+    @test eltype(pool) == Int
+    @test invpool == Dict(i=>Int(i) for i in 1.0:200.0)
 
-    refs, start, step, stop = _scaledlabel(1:typemax(Int16), 1, Int8)
+    refs, pool, invpool = scaledlabel(1:typemax(Int16), 1, Int8)
     @test refs == 1:typemax(Int16)
     @test eltype(refs) == Int16
+    @test valtype(invpool) == Int16
+
+    refs, pool, invpool = scaledlabel([missing, 1, 2], 1)
+    @test refs == 0:2
+    @test eltype(refs) == Int32
 end

--- a/test/ScaledArrays.jl
+++ b/test/ScaledArrays.jl
@@ -58,11 +58,13 @@ using DiffinDiffsBase: RefArray, validpool, scaledlabel
     @test refarray(sa) === sa.refs
     @test refvalue(sa, 1) == Date(1)
     @test refpool(sa) === sa.pool
+    @test invrefpool(sa) === sa.invpool
 
     ssa = view(sa, 3:4)
     @test refarray(ssa) == view(sa.refs, 3:4)
     @test refvalue(ssa, 1) == Date(1)
     @test refpool(ssa) === sa.pool
+    @test invrefpool(ssa) === sa.invpool
 
     @test sa[1] == Date(1)
     @test sa[1:2] == sa[[1,2]] == sa[(1:10).<3] == Date.(1:2)

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -1,3 +1,10 @@
+@testset "_mult!" begin
+    a = collect(0:5)
+    b = collect(1:6)
+    _mult!(a, b, 6)
+    @test a == 0:7:35
+end
+
 @testset "findcell" begin
     hrs = exampledata("hrs")
     @test_throws ArgumentError findcell((), hrs)

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -42,8 +42,11 @@ end
     t = settime(hrs, :wave, step=2, reftype=Int16)
     @test eltype(refarray(t)) == Int16
     @test sort!(unique(refarray(t))) == 1:3
+    t = settime(hrs, :wave, step=0.5)
+    @test eltype(t) == Float64
+
     t = settime(hrs, :wave, rotation=isodd.(hrs.wave))
-    @test eltype(t) == eltype(hrs.wave)
+    @test eltype(t) == RotatingTimeValue{Bool, eltype(hrs.wave)}
     @test eltype(refarray(t)) == RotatingTimeValue{Bool, Int32}
     @test all(x->x.rotation==isodd(x.time), t.refs)
 end

--- a/test/procedures.jl
+++ b/test/procedures.jl
@@ -87,6 +87,20 @@ end
         ret = (esample=df.wave_hosp.∈((8,11),), tr_rows=hrs.wave_hosp.==8)
         @test checkvars!(nt...) == ret
 
+        df.wave_hosp = Date.(df.wave_hosp)
+        @test_throws ArgumentError checkvars!(nt...)
+        df.wave = Date.(df.wave)
+        @test_throws ArgumentError checkvars!(nt...)
+        nt = merge(nt, (pr=nevertreated(Date(11)),))
+        @test_throws ArgumentError checkvars!(nt...)
+        df.wave_hosp = settime(df.wave_hosp, step=Year(1))
+        df.wave = settime(df.wave, step=Year(1))
+        @test checkvars!(nt...) == ret
+        nt = merge(nt, (pr=notyettreated(Date(11)),))
+        @test checkvars!(nt...) ==
+            (esample=(df.wave_hosp.∈((Date(8),Date(11)),)).&(df.wave.!=Date(11)),
+            tr_rows=(df.wave_hosp.==Date(8)).&(df.wave.!=Date(11)))
+
         df = DataFrame(hrs)
         rot = ifelse.(isodd.(df.hhidpn), 1, 2)
         df.wave_hosp = rotatingtime(rot, df.wave_hosp)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using DataFrames
 using Dates: Date, Year
 using DiffinDiffsBase: @fieldequal, unpack, @unpack, checktable, hastreat, parse_treat,
     isintercept, isomitsintercept, parse_intercept!,
-    ncol, nrow,
+    ncol, nrow, _mult!,
     _f, _byid, groupargs, copyargs, pool, checkdata, groupterms, checkvars!, makeweights,
     _totermset!, parse_didargs!, _treatnames, _parse_bycells!, _parse_subset, _nselected,
     treatindex, checktreatindex

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ include("testutils.jl")
 
 const tests = [
     "utils",
+    "time",
     "tables",
     "ScaledArrays",
     "terms",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Test
 using DiffinDiffsBase
 
-using DataAPI: refarray, refvalue, refpool
+using DataAPI: refarray, refvalue, refpool, invrefpool
 using DataFrames
 using Dates: Date, Year
 using DiffinDiffsBase: @fieldequal, unpack, @unpack, checktable, hastreat, parse_treat,

--- a/test/time.jl
+++ b/test/time.jl
@@ -1,0 +1,77 @@
+@testset "RotatingTimeValue" begin
+    rt0 = RotatingTimeValue(1, Date(1))
+    rt1 = RotatingTimeValue(1.0, Date(1))
+    @test RotatingTimeValue(typeof(rt0), 1.0, Date(1)) === rt0
+
+    @test rotatingtime(1.0, Date(1)) == rt1
+    rot = repeat(5:-1:1, inner=5)
+    time = repeat(1:5, outer=5)
+    rt = rotatingtime(rot, time)
+    @test eltype(rt) == RotatingTimeValue{Int, Int}
+    @test getfield.(rt, :rotation) == rot
+    @test getfield.(rt, :time) == time
+
+    rtd = rotatingtime(1, Date(1))
+    rt1 = rotatingtime(1, 1)
+    @test rtd + Year(1) == Year(1) + rtd == rotatingtime(1, Date(2))
+    @test rtd - Year(1) == rotatingtime(1, Date(0))
+    @test 1 - rt1 == rotatingtime(1, 0)
+    @test_throws MethodError Year(3) - rtd
+    @test 2 * rt1 == rt1 * 2 == rotatingtime(1, 2)
+
+    @test rt[1] - rt[2] == -1
+    @test_throws ArgumentError rt[1] - rt[6]
+
+    @test isless(rt[1], rt[2])
+    @test isless(rt[6], rt[1])
+    @test isless(rt[1], rt[7])
+    @test isless(rt[1], 2.0)
+    @test isless(1, rt[2])
+
+    @test rt[1] == RotatingTimeValue(Int32(5), Int32(1))
+    @test rt[1] == 1
+    @test 1 == rt[1]
+
+    @test zero(typeof(rt[1])) === RotatingTimeValue(0, 0)
+    @test iszero(RotatingTimeValue(1, 0))
+    @test !iszero(RotatingTimeValue(0, 1))
+
+    @test convert(typeof(rt[1]), RotatingTimeValue(Int32(5), Int32(1))) ===
+        RotatingTimeValue(5, 1)
+
+    @test checkindex(Bool, 1:5, rt1)
+    @test checkindex(Bool, 2:5, rt1) == false
+    X = 1:5
+    @test X[rt1] == 1
+    rts = rotatingtime(1, 2:3)
+    @test X[rts] == 2:3
+    @test_throws BoundsError (1:2)[rts]
+
+    @test sprint(show, rt[1]) == "5_1"
+    w = VERSION < v"1.6.0" ? "" : " "
+    @test sprint(show, MIME("text/plain"), rt[1]) == """
+        RotatingTimeValue{Int64,$(w)Int64}:
+          rotation: 5
+          time:     1"""
+end
+
+@testset "RotatingTimeRange" begin
+    rt1 = RotatingTimeValue(1, Date(1))
+    rt5 = RotatingTimeValue(2, Date(5))
+    rt1_1 = RotatingTimeValue(1, Date(5))
+    r = rt1:Year(1):rt5
+    @test r.value === rt1
+    @test r.range == Date(1):Year(1):Date(5)
+    @test first(r) === rt1
+    @test step(r) == Year(1)
+    @test last(r) === rt1_1
+    @test length(r) == 5
+
+    @test r[1] === rt1
+    @test r[end] === rt1_1
+
+    i1 = RotatingTimeValue(1, 1)
+    i5 = RotatingTimeValue(2, 5)
+    @test r[i1] === rt1
+    @test r[i5] === rt5
+end

--- a/test/time.jl
+++ b/test/time.jl
@@ -47,6 +47,10 @@
     @test X[rts] == 2:3
     @test_throws BoundsError (1:2)[rts]
 
+    @test iterate(rt1) == (rt1, nothing)
+    @test iterate(rt1, 1) === nothing
+    @test length(rt1) == 1
+
     @test sprint(show, rt[1]) == "5_1"
     w = VERSION < v"1.6.0" ? "" : " "
     @test sprint(show, MIME("text/plain"), rt[1]) == """

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -28,46 +28,6 @@ end
     @test size(exampledata(:mpdta)) == (2500,)
 end
 
-@testset "RotatingTimeValue" begin
-    @test rotatingtime(1.0, Date(1)) == RotatingTimeValue(1.0, Date(1))
-    rot = repeat(5:-1:1, inner=5)
-    time = repeat(1:5, outer=5)
-    rt = rotatingtime(rot, time)
-    @test eltype(rt) == RotatingTimeValue{Int, Int}
-    @test getfield.(rt, :rotation) == rot
-    @test getfield.(rt, :time) == time
-
-    rtd = rotatingtime(1, Date(1))
-    rt1 = rotatingtime(1, 1)
-    @test rtd + Year(1) == Year(1) + rtd == rotatingtime(1, Date(2))
-    @test rtd - Year(1) == rotatingtime(1, Date(0))
-    @test 1 - rt1 == rotatingtime(1, 0)
-    @test_throws MethodError Year(3) - rtd
-    @test 2 * rt1 == rt1 * 2 == rotatingtime(1, 2)
-
-    @test rt[1] - rt[2] == -1
-    @test_throws ArgumentError rt[1] - rt[6]
-
-    @test isless(rt[1], rt[2])
-    @test isless(rt[6], rt[1])
-    @test rt[1] == RotatingTimeValue(Int32(5), Int32(1))
-
-    @test checkindex(Bool, 1:5, rt1)
-    @test checkindex(Bool, 2:5, rt1) == false
-    X = 1:5
-    @test X[rt1] == 1
-    rts = rotatingtime(1, 2:3)
-    @test X[rts] == 2:3
-    @test_throws BoundsError (1:2)[rts]
-
-    @test sprint(show, rt[1]) == "5_1"
-    w = VERSION < v"1.6.0" ? "" : " "
-    @test sprint(show, MIME("text/plain"), rt[1]) == """
-        RotatingTimeValue{Int64,$(w)Int64}:
-          rotation: 5
-          time:     1"""
-end
-
 @testset "checktable" begin
     @test_throws ArgumentError checktable(rand(3,3))
     @test_throws ArgumentError checktable([(a=1, b=2), (a=1, b=2)])


### PR DESCRIPTION
1. `ScaledArray` now supports `DataAPI.invrefpool`.
2. Changes are made for future support of `ScaledArray` with `Missing` values, though it is not completed yet.
3. The new type `RotatingTimeRange` allows the elements of `ScaledArray` to be `RotatingTimeValue`s.