### PR TITLE
Add setindex! for ScaledArray and support missing values

### DIFF
--- a/src/DiffinDiffsBase.jl
+++ b/src/DiffinDiffsBase.jl
@@ -22,6 +22,7 @@ using Tables: AbstractColumns, istable, columnnames, getcolumn
 
 import Base: ==, +, -, *, isless, show, parent, view, diff
 import Base: eltype, firstindex, lastindex, getindex, iterate, length, sym_in
+import Missings: allowmissing, disallowmissing
 import StatsBase: coef, vcov, confint, nobs, dof_residual, responsename, coefnames, weights,
     coeftable
 import StatsModels: concrete_term, schema, termvars, lag, lead

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -94,7 +94,15 @@ function cellrows(cols::VecColumnTable, refrows::IdDict)
     ncol = length(cols)
     ncell = length(refrows)
     rows = Vector{Vector{Int}}(undef, ncell)
-    columns = AbstractVector[Vector{eltype(c)}(undef, ncell) for c in cols]
+    columns = Vector{AbstractVector}(undef, ncol)
+    for i in 1:ncol
+        c = cols[i]
+        if typeof(c) <: ScaledArray || typeof(c) <: SubArray{<:Any,1,<:ScaledArray}
+            columns[i] = similar(c, ncell)
+        else
+            columns[i] = Vector{eltype(c)}(undef, ncell)
+        end
+    end
     refs = Vector{keytype(refrows)}(undef, ncell)
     r = 0
     @inbounds for (k, v) in refrows

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -96,7 +96,7 @@ end
 
 Base.values(cols::VecColumnTable) = _columns(cols)
 Base.haskey(cols::VecColumnTable, key::Symbol) = haskey(_lookup(cols), key)
-Base.haskey(cols::VecColumnTable, i::Int) = 0 < i < length(_names(cols))
+Base.haskey(cols::VecColumnTable, i::Int) = 0 < i <= length(_names(cols))
 
 function Base.:(==)(x::VecColumnTable, y::VecColumnTable)
     size(x) == size(y) || return false

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -42,6 +42,16 @@ end
         sortslices(unique(hcat(hrs.wave, hrs.wave_hosp), dims=1), dims=1)
     @test propertynames(cells) == [:wave, :wave_hosp]
     @test rows[1] == intersect(findall(x->x==7, hrs.wave), findall(x->x==8, hrs.wave_hosp))
+
+    df = DataFrame(hrs)
+    df.wave = ScaledArray(df.wave, 1)
+    df.wave_hosp = ScaledArray(df.wave_hosp, 1)
+    cols1 = subcolumns(df, (:wave, :wave_hosp))
+    cells1, rows1 = cellrows(cols1, rows_dict)
+    @test rows1 == rows
+    @test cells1 == cells
+    @test cells1.wave isa ScaledArray
+    @test cells1.wave_hosp isa ScaledArray
 end
 
 @testset "settime" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using DiffinDiffsBase: @fieldequal, unpack, @unpack, checktable, hastreat, parse
     _totermset!, parse_didargs!, _treatnames, _parse_bycells!, _parse_subset, _nselected,
     treatindex, checktreatindex
 using LinearAlgebra: Diagonal
+using Missings: allowmissing, disallowmissing
 using PooledArrays: PooledArray
 using StatsBase: Weights, UnitWeights
 using StatsModels: termvars


### PR DESCRIPTION
Additionally, `cellrows` now handles columns from `ScaledArray`s so that the corresponding output columns are also `ScaledArray`s.