### PR TITLE
Add RotatingTimeArray and improve settime

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
+StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
@@ -34,6 +35,7 @@ Reexport = "0.2, 1"
 StatsBase = "0.33"
 StatsFuns = "0.9"
 StatsModels = "0.6.18"
+StructArrays = "0.5"
 Tables = "1.2"
 julia = "1.3"
 

--- a/src/DiffinDiffsBase.jl
+++ b/src/DiffinDiffsBase.jl
@@ -17,6 +17,7 @@ using StatsBase: CoefTable, Weights, stderror, uweights
 using StatsFuns: tdistccdf, tdistinvcdf
 @reexport using StatsModels
 using StatsModels: Schema
+using StructArrays: StructArray
 using Tables
 using Tables: AbstractColumns, istable, columnnames, getcolumn
 
@@ -37,7 +38,7 @@ export cb,
 
        RotatingTimeValue,
        rotatingtime,
-       RotatingRange,
+       RotatingTimeArray,
 
        VecColumnTable,
        VecColsRow,

--- a/src/ScaledArrays.jl
+++ b/src/ScaledArrays.jl
@@ -8,7 +8,7 @@ end
 """
     ScaledArray{T,R,N,RA,P} <: AbstractArray{T,N}
 
-An array type that stores data as indices of a range.
+Array type that stores data as indices of a range.
 
 # Fields
 - `refs::RA<:AbstractArray{R,N}`: an array of indices.
@@ -189,10 +189,7 @@ ScaledArray(sa::ScaledArray, step=nothing; reftype::Type=eltype(refarray(sa)),
     start=nothing, stop=nothing, xtype::Type=eltype(sa), usepool::Bool=true) =
         ScaledArray(sa, reftype, xtype, start, step, stop, usepool)
 
-Base.similar(sa::ScaledArray{T,R}, dims::Dims=size(sa)) where {T,R} =
-    ScaledArray(RefArray(ones(R, dims)), DataAPI.refpool(sa), Dict{T,R}())
-
-Base.similar(sa::SubArray{<:Any, <:Any, <:ScaledArray{T,R}}, dims::Dims=size(sa)) where {T,R} =
+Base.similar(sa::ScaledArrOrSub{T,R}, dims::Dims=size(sa)) where {T,R} =
     ScaledArray(RefArray(ones(R, dims)), DataAPI.refpool(sa), Dict{T,R}())
 
 Base.similar(sa::ScaledArrOrSub, dims::Int...) = similar(sa, dims)

--- a/src/time.jl
+++ b/src/time.jl
@@ -25,20 +25,6 @@ This method simply broadcasts the default constructor over the arguments.
 """
 rotatingtime(rotation, time) = RotatingTimeValue.(rotation, time)
 
-+(x::RotatingTimeValue, y) = RotatingTimeValue(x.rotation, x.time + y)
-+(x, y::RotatingTimeValue) = RotatingTimeValue(y.rotation, x + y.time)
--(x::RotatingTimeValue, y) = RotatingTimeValue(x.rotation, x.time - y)
--(x, y::RotatingTimeValue) = RotatingTimeValue(y.rotation, x - y.time)
-*(x::RotatingTimeValue, y) = RotatingTimeValue(x.rotation, x.time * y)
-*(x, y::RotatingTimeValue) = RotatingTimeValue(y.rotation, x * y.time)
-
-function -(x::RotatingTimeValue, y::RotatingTimeValue)
-    rx = x.rotation
-    ry = y.rotation
-    rx == ry || throw(ArgumentError("x has rotation $rx while y has rotation $ry"))
-    return x.time - y.time
-end
-
 # Compare time first
 isless(x::RotatingTimeValue, y::RotatingTimeValue) =
     isequal(x.time, y.time) ? isless(x.rotation, y.rotation) : isless(x.time, y.time)
@@ -48,8 +34,16 @@ isless(x, y::RotatingTimeValue) = isless(x, y.time)
 isless(::RotatingTimeValue, ::Missing) = true
 isless(::Missing, ::RotatingTimeValue) = false
 
-==(x::RotatingTimeValue, y::RotatingTimeValue) =
-    x.rotation == y.rotation && x.time == y.time
+Base.isequal(x::RotatingTimeValue, y::RotatingTimeValue) =
+    isequal(x.rotation, y.rotation) && isequal(x.time, y.time)
+
+function ==(x::RotatingTimeValue, y::RotatingTimeValue)
+    req = x.rotation == y.rotation
+    isequal(req, missing) && return missing
+    teq = x.time == y.time
+    isequal(teq, missing) && return missing
+    return req && teq
+end
 
 ==(x::RotatingTimeValue, y) = x.time == y
 ==(x, y::RotatingTimeValue) = x == y.time
@@ -58,21 +52,21 @@ isless(::Missing, ::RotatingTimeValue) = false
 
 Base.zero(::Type{RotatingTimeValue{R,T}}) where {R,T} = RotatingTimeValue(zero(R), zero(T))
 Base.iszero(x::RotatingTimeValue) = iszero(x.time)
+Base.one(::Type{RotatingTimeValue{R,T}}) where {R,T} = RotatingTimeValue(one(R), one(T))
+Base.isone(x::RotatingTimeValue) = isone(x.time)
 
 Base.convert(::Type{RotatingTimeValue{R,T}}, x::RotatingTimeValue) where {R,T} =
     RotatingTimeValue(convert(R, x.rotation), convert(T, x.time))
 
-Base.checkindex(::Type{Bool}, inds::AbstractUnitRange, i::RotatingTimeValue) =
-    checkindex(Bool, inds, i.time)
-
-@propagate_inbounds getindex(X::AbstractArray, i::RotatingTimeValue) = getindex(X, i.time)
+Base.nonmissingtype(::Type{RotatingTimeValue{R,T}}) where {R,T} =
+    RotatingTimeValue{nonmissingtype(R), nonmissingtype(T)}
 
 Base.iterate(x::RotatingTimeValue) = (x, nothing)
 Base.iterate(x::RotatingTimeValue, ::Any) = nothing
 
 Base.length(x::RotatingTimeValue) = 1
 
-show(io::IO, x::RotatingTimeValue) = print(io, x.rotation, "_", x.time)
+show(io::IO, x::RotatingTimeValue) = print(io, '[', x.rotation, "]:", x.time)
 function show(io::IO, ::MIME"text/plain", x::RotatingTimeValue)
     println(io, typeof(x), ':')
     println(io, "  rotation: ", x.rotation)
@@ -80,30 +74,47 @@ function show(io::IO, ::MIME"text/plain", x::RotatingTimeValue)
 end
 
 """
-    RotatingTimeRange{T<:RotatingTimeValue,R<:AbstractRange} <: AbstractRange{T}
+    RotatingTimeArray{T<:RotatingTimeValue,N,C,I} <: AbstractArray{T,N}
 
-A range type that wraps a [`RotationTimeValue`](@ref) with a range of type `R`
-for producing a range of [`RotationTimeValue`](@ref)s.
-It can be created with the syntax `a:b:c` when `a` and `c` are [`RotationTimeValue`](@ref)s.
+Array type for [`RotatingTimeValue`](@ref)s that stores
+the field values `rotation` and `time` in two arrays for efficiency.
+The two arrays that hold the field values for all elements can be accessed as properties.
 """
-struct RotatingTimeRange{T<:RotatingTimeValue,R<:AbstractRange} <: AbstractRange{T}
-    value::T
-    range::R
+struct RotatingTimeArray{T<:RotatingTimeValue,N,C,I} <: AbstractArray{T,N}
+    a::StructArray{T,N,C,I}
+    RotatingTimeArray(a::StructArray{T,N,C,I}) where {T,N,C,I} = new{T,N,C,I}(a)
 end
 
-Base.:(:)(start::RotatingTimeValue, step, stop::RotatingTimeValue) =
-    RotatingTimeRange(start, start.time:step:stop.time)
+"""
+    RotatingTimeArray(rotation::AbstractArray, time::AbstractArray)
 
-Base.first(r::RotatingTimeRange) = RotatingTimeValue(r.value.rotation, first(r.range))
-Base.step(r::RotatingTimeRange) = step(r.range)
-Base.last(r::RotatingTimeRange) = RotatingTimeValue(r.value.rotation, last(r.range))
+Construct a [`RotatingTimeValue`](@ref) from arrays of `rotation` and `time`.
+"""
+function RotatingTimeArray(rotation::AbstractArray, time::AbstractArray)
+    a = StructArray{RotatingTimeValue{eltype(rotation), eltype(time)}}((rotation, time))
+    return RotatingTimeArray(a)
+end
 
-Base.length(r::RotatingTimeRange) = length(r.range)
+_getarray(a::RotatingTimeArray) = getfield(a, :a)
 
-@propagate_inbounds Base.getindex(r::RotatingTimeRange{T}, i::Int) where T =
-    RotatingTimeValue(T, r.value.rotation, r.range[i])
+Base.size(a::RotatingTimeArray) = size(_getarray(a))
+Base.IndexStyle(::Type{<:RotatingTimeArray{<:Any,<:Any,<:Any,I}}) where I =
+    I === Int ? IndexLinear() : IndexCartesian()
 
-@propagate_inbounds Base.getindex(r::RotatingTimeRange{T}, i::RotatingTimeValue) where T =
-    RotatingTimeValue(T, i.rotation, r.range[i.time])
+Base.@propagate_inbounds Base.getindex(a::RotatingTimeArray, i::Int) = _getarray(a)[i]
+Base.@propagate_inbounds Base.setindex!(a::RotatingTimeArray, v, i::Int) =
+    setindex!(_getarray(a), v, i)
+
+@inline Base.view(a::RotatingTimeArray, I...) = RotatingTimeArray(view(_getarray(a), I...))
+
+Base.similar(a::RotatingTimeArray, dims::Dims=size(a)) =
+    RotatingTimeArray(similar(_getarray(a), dims))
+
+Base.similar(a::RotatingTimeArray, dims::Int...) = similar(a, dims)
+
+Base.getproperty(a::RotatingTimeArray, n::Symbol) = getproperty(_getarray(a), n)
+
+DataAPI.refarray(a::RotatingTimeArray) =
+    RotatingTimeArray(DataAPI.refarray(a.rotation), DataAPI.refarray(a.time))
 
 const ValidTimeType = Union{Signed, TimeType, Period, RotatingTimeValue}

--- a/src/time.jl
+++ b/src/time.jl
@@ -66,7 +66,7 @@ Base.iterate(x::RotatingTimeValue, ::Any) = nothing
 
 Base.length(x::RotatingTimeValue) = 1
 
-show(io::IO, x::RotatingTimeValue) = print(io, '[', x.rotation, "]:", x.time)
+show(io::IO, x::RotatingTimeValue) = print(io, x.rotation, '_', x.time)
 function show(io::IO, ::MIME"text/plain", x::RotatingTimeValue)
     println(io, typeof(x), ':')
     println(io, "  rotation: ", x.rotation)
@@ -102,8 +102,13 @@ Base.IndexStyle(::Type{<:RotatingTimeArray{<:Any,<:Any,<:Any,I}}) where I =
     I === Int ? IndexLinear() : IndexCartesian()
 
 Base.@propagate_inbounds Base.getindex(a::RotatingTimeArray, i::Int) = _getarray(a)[i]
+Base.@propagate_inbounds Base.getindex(a::RotatingTimeArray, I) =
+    RotatingTimeArray(_getarray(a).rotation[I], _getarray(a).time[I])
+
 Base.@propagate_inbounds Base.setindex!(a::RotatingTimeArray, v, i::Int) =
     setindex!(_getarray(a), v, i)
+Base.@propagate_inbounds Base.setindex!(a::RotatingTimeArray, v, I) =
+    setindex!(_getarray(a), v, I)
 
 @inline Base.view(a::RotatingTimeArray, I...) = RotatingTimeArray(view(_getarray(a), I...))
 

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -44,14 +44,24 @@ end
     @test rows[1] == intersect(findall(x->x==7, hrs.wave), findall(x->x==8, hrs.wave_hosp))
 
     df = DataFrame(hrs)
-    df.wave = ScaledArray(df.wave, 1)
-    df.wave_hosp = ScaledArray(df.wave_hosp, 1)
+    df.wave = ScaledArray(hrs.wave, 1)
+    df.wave_hosp = ScaledArray(hrs.wave_hosp, 1)
     cols1 = subcolumns(df, (:wave, :wave_hosp))
     cells1, rows1 = cellrows(cols1, rows_dict)
     @test rows1 == rows
     @test cells1 == cells
     @test cells1.wave isa ScaledArray
     @test cells1.wave_hosp isa ScaledArray
+
+    rot = ones(size(df, 1))
+    df.wave = RotatingTimeArray(rot, hrs.wave)
+    df.wave_hosp = RotatingTimeArray(rot, hrs.wave_hosp)
+    cols2 = subcolumns(df, (:wave, :wave_hosp))
+    cells2, rows2 = cellrows(cols2, rows_dict)
+    @test rows2 == rows
+    @test cells2 == cells
+    @test cells2.wave isa RotatingTimeArray
+    @test cells2.wave_hosp isa RotatingTimeArray
 end
 
 @testset "settime aligntime" begin

--- a/test/procedures.jl
+++ b/test/procedures.jl
@@ -97,12 +97,12 @@ end
         @test_throws ArgumentError checkvars!(nt...)
         nt = merge(nt, (pr=nevertreated(Date(11)),))
         @test_throws ArgumentError checkvars!(nt...)
-        df.wave = settime(df.wave, step=Year(1))
-        df.wave_hosp = settime(df.wave_hosp, step=Year(1))
+        df.wave = settime(df.wave, Year(1))
+        df.wave_hosp = settime(df.wave_hosp, Year(1))
         @test_throws ArgumentError checkvars!(nt...)
         df.wave_hosp = aligntime(df, :wave_hosp, :wave)
         @test checkvars!(nt...) == ret
-        nt = merge(nt, (pr=notyettreated(Date(11)),esample=trues(N)))
+        nt = merge(nt, (pr=notyettreated(Date(11)), esample=trues(N)))
         ret = checkvars!(nt...)
         @test ret == (esample=(df.wave_hosp.∈((Date(8),Date(11)),)).&(df.wave.!=Date(11)),
             tr_rows=(df.wave_hosp.==Date(8)).&(df.wave.!=Date(11)))
@@ -125,33 +125,32 @@ end
         df.wave = rotatingtime(rot, df.wave)
         e = rotatingtime((1,2), 11)
         nt = merge(nt, (data=df, tr=dynamic(:wave, -1), pr=nevertreated(e), treatintterms=TermSet(), xterms=TermSet(), esample=trues(N)))
+        # Check RotatingTimeArray
+        @test_throws ArgumentError checkvars!(nt...)
+        df.wave_hosp = settime(hrs.wave_hosp, rotation=rot)
+        df.wave = settime(hrs.wave, rotation=rot)
+        # Check aligntime
+        @test_throws ArgumentError checkvars!(nt...)
+        df.wave_hosp = aligntime(df.wave_hosp, df.wave)
         ret1 = checkvars!(nt...)
         @test ret1 == (esample=trues(N), tr_rows=hrs.wave_hosp.!=11)
-        df.wave_hosp = rotatingtime(2, hrs.wave_hosp)
-        df.wave = rotatingtime(2, hrs.wave)
+        df.wave_hosp = settime(hrs.wave_hosp, start=7, rotation=ones(N))
+        df.wave = settime(hrs.wave, rotation=ones(N))
+        # Check the match of field type of pr.e
+        @test_throws ArgumentError checkvars!(nt...)
+        df.wave_hosp = settime(hrs.wave_hosp, start=7, rotation=ones(Int, N))
+        df.wave = settime(hrs.wave, rotation=ones(Int, N))
         nt = merge(nt, (esample=trues(N), pr=notyettreated(e),))
         ret2 = checkvars!(nt...)
         @test ret2 == (esample=hrs.wave.!=11, tr_rows=(hrs.wave_hosp.!=11).&(hrs.wave.!=11))
 
-        df.wave = settime(Date.(hrs.wave), step=Year(1), rotation=rot)
-        df.wave_hosp = rotatingtime(rot, Date.(hrs.wave_hosp))
-        df.wave_hosp = aligntime(df, :wave_hosp, :wave)
+        df.wave = settime(Date.(hrs.wave), Year(1), rotation=rot)
+        df.wave_hosp = settime(Date.(hrs.wave_hosp), Year(1), start=Date(7), rotation=rot)
         e = rotatingtime((1,2), Date(11))
         nt = merge(nt, (esample=trues(N), pr=nevertreated(e)))
         @test checkvars!(nt...) == ret1
         nt = merge(nt, (esample=trues(N), pr=notyettreated(e),))
         @test checkvars!(nt...) == ret2
-
-        allowmissing!(df, :wave_hosp)
-        df.wave_hosp .= ifelse.(hrs.wave_hosp.==8, missing, df.wave_hosp)
-        nt = merge(nt, (esample=trues(N), pr=nevertreated(e)))
-        ret = checkvars!(nt...)
-        @test ret.esample == (hrs.wave_hosp.!=8)
-        @test ret.tr_rows == ret.esample.&(hrs.wave_hosp.!=11)
-        nt = merge(nt, (esample=trues(N), pr=notyettreated(e)))
-        ret = checkvars!(nt...)
-        @test ret.esample == (hrs.wave_hosp.!=8).&(hrs.wave.!=11)
-        @test ret.tr_rows == ret.esample.&(hrs.wave_hosp.!=11)
     end
 
     @testset "StatsStep" begin

--- a/test/procedures.jl
+++ b/test/procedures.jl
@@ -144,6 +144,17 @@ end
         ret2 = checkvars!(nt...)
         @test ret2 == (esample=hrs.wave.!=11, tr_rows=(hrs.wave_hosp.!=11).&(hrs.wave.!=11))
 
+        # RotatingTimeArray with time field of type Array
+        df.wave_hosp = RotatingTimeArray(rot, hrs.wave_hosp)
+        df.wave = RotatingTimeArray(rot, hrs.wave)
+        e = rotatingtime((1,2), (10,11))
+        nt = merge(nt, (esample=trues(N), pr=notyettreated(e)))
+        ret3 = checkvars!(nt...)
+        ret3e = (hrs.wave.!=11).&(.!((hrs.wave.==10).&(rot.==1))).&
+            (.!((hrs.wave_hosp.==11).&(rot.==1)))
+        @test ret3 == (esample=ret3e, tr_rows=ret3e.&
+            (hrs.wave_hosp.!=11).&(.!((hrs.wave_hosp.==10).&(rot.==1))))
+
         df.wave = settime(Date.(hrs.wave), Year(1), rotation=rot)
         df.wave_hosp = settime(Date.(hrs.wave_hosp), Year(1), start=Date(7), rotation=rot)
         e = rotatingtime((1,2), Date(11))

--- a/test/time.jl
+++ b/test/time.jl
@@ -68,8 +68,8 @@ end
 
     a[1] = RotatingTimeValue(2, 2.0)
     @test a[1] == RotatingTimeValue(2, 2.0)
-    a[5:-1:1] .= RotatingTimeValue(2, 2.0)
-    @test all(a .== RotatingTimeValue(2, 2.0))
+    a[1:2] = a[3:4]
+    @test a[1:2] == a[3:4]
 
     v = view(a, 2:4)
     @test v isa RotatingTimeArray

--- a/test/time.jl
+++ b/test/time.jl
@@ -11,17 +11,6 @@
     @test getfield.(rt, :rotation) == rot
     @test getfield.(rt, :time) == time
 
-    rtd = rotatingtime(1, Date(1))
-    rt1 = rotatingtime(1, 1)
-    @test rtd + Year(1) == Year(1) + rtd == rotatingtime(1, Date(2))
-    @test rtd - Year(1) == rotatingtime(1, Date(0))
-    @test 1 - rt1 == rotatingtime(1, 0)
-    @test_throws MethodError Year(3) - rtd
-    @test 2 * rt1 == rt1 * 2 == rotatingtime(1, 2)
-
-    @test rt[1] - rt[2] == -1
-    @test_throws ArgumentError rt[1] - rt[6]
-
     @test isless(rt[1], rt[2])
     @test isless(rt[6], rt[1])
     @test isless(rt[1], rt[7])
@@ -30,7 +19,12 @@
     @test isless(rt[1], missing)
     @test !isless(missing, rt[1])
 
+    @test isequal(rt[1], RotatingTimeValue(5, 1))
+
     @test rt[1] == RotatingTimeValue(Int32(5), Int32(1))
+    @test isequal(rt[1] == RotatingTimeValue(missing, 1), missing)
+    @test isequal(rt[1] == RotatingTimeValue(5, missing), missing)
+    @test isequal(rt[1] == RotatingTimeValue(1, missing), missing)
     @test rt[1] == 1
     @test 1 == rt[1]
     @test isequal(rt[1] == missing, missing)
@@ -39,23 +33,21 @@
     @test zero(typeof(rt[1])) === RotatingTimeValue(0, 0)
     @test iszero(RotatingTimeValue(1, 0))
     @test !iszero(RotatingTimeValue(0, 1))
+    @test one(typeof(rt[1])) === RotatingTimeValue(1, 1)
+    @test isone(RotatingTimeValue(1, 1))
+    @test !isone(RotatingTimeValue(1, 0))
 
     @test convert(typeof(rt[1]), RotatingTimeValue(Int32(5), Int32(1))) ===
         RotatingTimeValue(5, 1)
 
-    @test checkindex(Bool, 1:5, rt1)
-    @test checkindex(Bool, 2:5, rt1) == false
-    X = 1:5
-    @test X[rt1] == 1
-    rts = rotatingtime(1, 2:3)
-    @test X[rts] == 2:3
-    @test_throws BoundsError (1:2)[rts]
+    @test nonmissingtype(RotatingTimeValue{Union{Int,Missing}, Union{Int,Missing}}) ==
+        RotatingTimeValue{Int, Int}
 
     @test iterate(rt1) == (rt1, nothing)
     @test iterate(rt1, 1) === nothing
     @test length(rt1) == 1
 
-    @test sprint(show, rt[1]) == "5_1"
+    @test sprint(show, rt[1]) == "[5]:1"
     w = VERSION < v"1.6.0" ? "" : " "
     @test sprint(show, MIME("text/plain"), rt[1]) == """
         RotatingTimeValue{Int64,$(w)Int64}:
@@ -63,23 +55,27 @@
           time:     1"""
 end
 
-@testset "RotatingTimeRange" begin
-    rt1 = RotatingTimeValue(1, Date(1))
-    rt5 = RotatingTimeValue(2, Date(5))
-    rt1_1 = RotatingTimeValue(1, Date(5))
-    r = rt1:Year(1):rt5
-    @test r.value === rt1
-    @test r.range == Date(1):Year(1):Date(5)
-    @test first(r) === rt1
-    @test step(r) == Year(1)
-    @test last(r) === rt1_1
-    @test length(r) == 5
+@testset "RotatingTimeArray" begin
+    rot = collect(1:5)
+    time = collect(1.0:5.0)
+    a = RotatingTimeArray(rot, time)
+    @test eltype(a) == RotatingTimeValue{Int, Float64}
+    @test size(a) == (5,)
+    @test IndexStyle(typeof(a)) == IndexLinear()
 
-    @test r[1] === rt1
-    @test r[end] === rt1_1
+    @test a[1] == RotatingTimeValue(1, 1.0)
+    a[1] = RotatingTimeValue(2, 2.0)
+    @test a[1] == RotatingTimeValue(2, 2.0)
 
-    i1 = RotatingTimeValue(1, 1)
-    i5 = RotatingTimeValue(2, 5)
-    @test r[i1] === rt1
-    @test r[i5] === rt5
+    v = view(a, 2:4)
+    @test v isa RotatingTimeArray
+    @test v == a[2:4]
+
+    @test typeof(similar(a)) == typeof(a)
+    @test size(similar(a, 3)) == (3,)
+
+    @test v.rotation == rot[2:4]
+    @test v.time == time[2:4]
+
+    @test refarray(a).rotation == rot
 end

--- a/test/time.jl
+++ b/test/time.jl
@@ -47,7 +47,7 @@
     @test iterate(rt1, 1) === nothing
     @test length(rt1) == 1
 
-    @test sprint(show, rt[1]) == "[5]:1"
+    @test sprint(show, rt[1]) == "5_1"
     w = VERSION < v"1.6.0" ? "" : " "
     @test sprint(show, MIME("text/plain"), rt[1]) == """
         RotatingTimeValue{Int64,$(w)Int64}:
@@ -64,8 +64,12 @@ end
     @test IndexStyle(typeof(a)) == IndexLinear()
 
     @test a[1] == RotatingTimeValue(1, 1.0)
+    @test a[5:-1:1] == RotatingTimeArray(rot[5:-1:1], time[5:-1:1])
+
     a[1] = RotatingTimeValue(2, 2.0)
     @test a[1] == RotatingTimeValue(2, 2.0)
+    a[5:-1:1] .= RotatingTimeValue(2, 2.0)
+    @test all(a .== RotatingTimeValue(2, 2.0))
 
     v = view(a, 2:4)
     @test v isa RotatingTimeArray


### PR DESCRIPTION
For panels with rotating sampling design, a dedicated array type `RotatingTimeArray` now replaces the `ScaledArray` with `RotatingTimeRange`. The former is a wrapper around `StructArray` from `StructArrays.jl`. It avoids the complication from using `RotatingTimeValue` as reference values, especially when the time values need to be represented with a `ScaledArray`. The downside is that `RotatingTimeArray` does not support missing values for now, which would require extra work.