### PR TITLE
Improve apply methods and fix issues with overlap!

### DIFF
--- a/src/did.jl
+++ b/src/did.jl
@@ -179,8 +179,8 @@ collect estimation results for difference-in-differences
 with treatment of type `TR`.
 
 # Interface definition
-| Required methods | Default definition | Brief description |
-|---|---|---|
+| Required method | Default definition | Brief description |
+|:---|:---|:---|
 | `coef(r)` | `r.coef` | Vector of point estimates for all coefficients including covariates |
 | `vcov(r)` | `r.vcov` | Variance-covariance matrix for estimates in `coef` |
 | `vce(r)` | `r.vce` | Covariance estimator |
@@ -189,8 +189,8 @@ with treatment of type `TR`.
 | `nobs(r)` | `r.nobs` | Number of observations (table rows) involved in estimation |
 | `outcomename(r)` | `r.yname` | Name of the outcome variable |
 | `coefnames(r)` | `r.coefnames` | Names (`Vector{String}`) of all coefficients including covariates |
-| `treatcells(r)` | `r.treatcells` | Tables.jl-compatible tabular description of treatment coefficients in the order of `coefnames` (without covariates) |
-| `weights(r)` | `r.weights` | Column name of the weight variable (if specified) |
+| `treatcells(r)` | `r.treatcells` | `Tables.jl`-compatible tabular description of treatment coefficients in the order of `coefnames` (without covariates) |
+| `weights(r)` | `r.weights` | Name of the column containing sample weights (if specified) |
 | `ntreatcoef(r)` | `size(treatcells(r), 1)` | Number of treatment coefficients |
 | `treatcoef(r)` | `view(coef(r), 1:ntreatcoef(r))` | A view of treatment coefficients |
 | `treatvcov(r)` | `(N = ntreatcoef(r); view(vcov(r), 1:N, 1:N))` | A view of variance-covariance matrix for treatment coefficients |
@@ -388,7 +388,7 @@ coefnames(r::AbstractDIDResult) = r.coefnames
 """
     treatcells(r::AbstractDIDResult)
 
-Return a Tables.jl-compatible tabular description of treatment coefficients
+Return a `Tables.jl`-compatible tabular description of treatment coefficients
 in the order of coefnames (without covariates).
 """
 treatcells(r::AbstractDIDResult) = r.treatcells
@@ -550,7 +550,7 @@ end
 
 # Helper functions for handling subset option that may involves Pairs
 _parse_subset(r::AbstractDIDResult, by::Pair, fill_x::Bool) =
-    (inds = apply(treatcells(r), by); fill_x && _fill_x!(r, inds); return inds)
+    (inds = apply_and(treatcells(r), by); fill_x && _fill_x!(r, inds); return inds)
 
 function _parse_subset(r::AbstractDIDResult, inds, fill_x::Bool)
     eltype(inds) <: Pair || return inds
@@ -911,7 +911,7 @@ function post!(f, ::StataPostHDF, r::AbstractDIDResult;
     if at !== nothing
         pat = _postat!(f, r, at)
         pat === nothing && throw(ArgumentError(
-            "Keyword argument of type $(typeof(at)) is not accepted."))
+            "Keyword argument `at` of type $(typeof(at)) is not accepted."))
         pat == false || length(pat) != length(coef(r)) && throw(ArgumentError(
             "The length of at ($(length(pat))) does not match the length of b ($(length(coef(r))))"))
     end

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -44,7 +44,7 @@ are the same within each group.
 Instead of directly providing the relevant portions of columns as
 [`VecColumnTable`](@ref)``,
 one may specify the `names` of columns from
-`data` of any Tables.jl-compatible table type
+`data` of any `Tables.jl`-compatible table type
 over selected rows indicated by `esample`.
 Note that unless `esample` covers all rows of `data`,
 the row indices are those for the subsample selected based on `esample`
@@ -170,7 +170,7 @@ the [`ScaledArray`](@ref) `time`.
 If `time` is a [`RotatingTimeArray`](@ref) with the `time` field being a [`ScaledArray`](@ref),
 the returned array is also a [`RotatingTimeArray`](@ref)
 with the `time` field being the converted [`ScaledArray`](@ref).
-Alternative, the arrays may be specified with a Tables.jl-compatible `data` table
+Alternative, the arrays may be specified with a `Tables.jl`-compatible `data` table
 and column indices `colname` and `timename`.
 See also [`settime`](@ref).
 
@@ -229,7 +229,7 @@ as a table containing the relevant columns or as arrays.
 that is returned by [`settime`](@ref).
 
 # Arguments
-- `data`: a Tables.jl-compatible data table.
+- `data`: a `Tables.jl`-compatible data table.
 - `idname::Union{Symbol,Integer}`: the name of the column in `data` that contains unit IDs.
 - `timename::Union{Symbol,Integer}`: the name of the column in `data` that contains time values.
 - `id::AbstractArray`: the array containing unit IDs (only needed for the alternative method).

--- a/src/parallels.jl
+++ b/src/parallels.jl
@@ -22,7 +22,7 @@ show(io::IO, ::Unconditional) =
 """
     unconditional()
 
-Alias of [`Unconditional()`](@ref).
+Alias for [`Unconditional()`](@ref).
 """
 unconditional() = Unconditional()
 
@@ -56,7 +56,7 @@ show(io::IO, ::Exact) =
 """
     exact()
 
-Alias of [`Exact()`](@ref).
+Alias for [`Exact()`](@ref).
 """
 exact() = Exact()
 
@@ -252,7 +252,7 @@ See also [`notyettreated`](@ref).
 
 # Fields
 - `e::Tuple{Vararg{ValidTimeType}}`: group indices for units that received the treatment relatively late.
-- `ecut::Tuple{Vararg{ValidTimeType}}`: user-specified period(s) when units in a group in `e` started to receive treatment.
+- `ecut::Tuple{Vararg{ValidTimeType}}`: user-specified period(s) when units in a group in `e` started to receive treatment or show anticipation effects.
 - `c::C`: an instance of [`ParallelCondition`](@ref).
 - `s::S`: an instance of [`ParallelStrength`](@ref).
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -156,7 +156,7 @@ end
 # Check whether the input data is a column table
 function checktable(data)
     istable(data) ||
-        throw(ArgumentError("data of type $(typeof(data)) is not Tables.jl-compatible"))
+        throw(ArgumentError("data of type $(typeof(data)) is not `Tables.jl`-compatible"))
     Tables.columnaccess(data) ||
         throw(ArgumentError("data of type $(typeof(data)) is not a column table"))
 end

--- a/test/procedures.jl
+++ b/test/procedures.jl
@@ -5,9 +5,11 @@
         ret = checkdata!(nt...)
         @test ret.esample == trues(size(hrs,1))
 
-        nt = merge(nt, (weightname=:rwthh, subset=hrs.male.==1))
+        ismale = hrs.male.==1
+        nt = merge(nt, (weightname=:rwthh, subset=ismale))
         ret = checkdata!(nt...)
-        @test ret.esample == BitArray(hrs.male)
+        @test ret.esample == ismale
+        @test ret.esample !== ismale
 
         df = DataFrame(hrs)
         allowmissing!(df, :rwthh)
@@ -113,6 +115,11 @@ end
         @test checkvars!(nt...) ==
             (esample=.!(hrs.wave_hosp.∈(10,)).& .!(hrs.wave.∈((10,11),)),
             tr_rows=(.!(hrs.wave_hosp.∈((10,11),)).& .!(hrs.wave.∈((10,11),))))
+
+        nt = merge(nt, (pr=notyettreated(10),
+            esample=.!((hrs.wave_hosp.==10).&(hrs.wave.==9))))
+        @test checkvars!(nt...) == (esample=(hrs.wave.<9).&(hrs.wave_hosp.<=10),
+            tr_rows=(hrs.wave.<9).&(hrs.wave_hosp.<=9))
 
         nt = merge(nt, (pr=us, treatintterms=TermSet(term(:male)),
             xterms=TermSet(term(:white)), esample=trues(N)))


### PR DESCRIPTION
`apply`, `apply_and!` and `apply_and` now use `map` to apply functions to reduce the need for recompilation.
`overlap!` for `NotYetTreatedParallel` now collects the overlapping time periods after the invalid cohorts are excluded.
If `subset` is specified, it is copied to avoid potential issues when the same vector is reused elsewhere.
Methods of `_parse_subset` are added for `VecColumnTable`.